### PR TITLE
Interface public draw

### DIFF
--- a/static/css/eas-base.css
+++ b/static/css/eas-base.css
@@ -153,7 +153,7 @@ ul.nav.navbar-nav {
     align-items: center;
     height: 80px;
     background-color: #F0F8F1;
-    padding: 0 15px 0 15px;
+    padding: 0 0 0 0;
     border-bottom: 1px #E7E7E7 solid;
 }
 
@@ -184,6 +184,7 @@ ul.nav.navbar-nav {
 }
 
 .info-public-draw .subtitle.focus {
+    font-size: 17px;
     font-weight: bold;
     color: #4cae4c;
 }

--- a/static/css/eas-base.css
+++ b/static/css/eas-base.css
@@ -141,6 +141,57 @@ ul.nav.navbar-nav {
 
 }
 
+/***** PUBLIC DRAW *****/
+.info-public-draw {
+    display: -webkit-flex;
+    display: flex;
+    -webkit-flex-direction: row;
+    flex-direction: row;
+    -webkit-justify-content: flex-start;
+    justify-content: flex-start;
+    -webkit-align-items: center;
+    align-items: center;
+    height: 80px;
+    background-color: #F0F8F1;
+    padding: 0 15px 0 15px;
+    border-bottom: 1px #E7E7E7 solid;
+}
+
+
+
+.info-public-draw .cancel {
+    flex: 0 0 40px;
+    color: #6f6f6f;
+}
+
+.info-public-draw .help-text {
+    text-align: center;
+    flex: auto;
+}
+
+.info-public-draw .title {
+    margin-top: 10px;
+    padding-bottom:5px;
+    font-size: 20px;
+    color: #4cae4c;
+    border-bottom: 2px #c8e7ca solid;
+}
+
+.info-public-draw .subtitle {
+    margin: 10px 0 10px;
+    font-size: 16px;
+    color: #979797;
+}
+
+.info-public-draw .subtitle.focus {
+    font-weight: bold;
+    color: #4cae4c;
+}
+
+.info-public-draw .subtitle.done {
+    font-weight: bold;
+}
+
 
 /* ---------------- FOOTER --------------------- */
 .footer {

--- a/static/css/eas-draw-base.css
+++ b/static/css/eas-draw-base.css
@@ -70,6 +70,13 @@ a.fa:focus {
     color: #404b6f;
 }
 
+/* Box containing the selected level of restriction when creating a public draw */
+.public-draw-restriction {
+    background-color: #FCFCFC;
+    border: 1px #D7D7D7 solid;
+    border-radius: 5px;
+}
+
 /* Slidebar to choose the level of access to public draws */
 .slide-bar-container {
 

--- a/static/css/eas-draw-base.css
+++ b/static/css/eas-draw-base.css
@@ -182,9 +182,7 @@ a.fa:focus {
    line-height: 26px;
 }
 
-.btn-toss,
-.btn-try,
-.btn-next {
+.btn-row {
     margin-top: 13px;
     margin-bottom: 13px;
 }

--- a/static/css/eas-home.css
+++ b/static/css/eas-home.css
@@ -1,36 +1,3 @@
-/***** PUBLIC DRAW *****/
-.info-public-draw {
-    display: -webkit-flex;
-    display: flex;
-    -webkit-flex-direction: row;
-    flex-direction: row;
-    -webkit-justify-content: flex-start;
-    justify-content: flex-start;
-    -webkit-align-items: center;
-    align-items: center;
-    height: 60px;
-    background-color: #F0F8F1;
-    padding: 0 15px 0 15px;
-    border-bottom: 1px #E7E7E7 solid;
-}
-
-.info-public-draw .help-text {
-    text-align: left;
-    flex: auto;
-}
-
-
-.info-public-draw .title {
-    font-size: 20px;
-    color: #4cae4c;
-}
-
-
-.info-public-draw .cancel {
-    flex: 0 0 40px;
-    color: #6f6f6f;
-}
-
 
 .container-draws {
     padding-top: 10px;

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -280,6 +280,23 @@
                     </div>
                 {% endif %}
 
+                <!-- Public Draw Info -->
+                <div class="row">
+                    {% if is_public%}
+                        <div class="info-public-draw">
+                            <div class="help-text">
+                                <span class="col-xs-10 col-xs-offset-1 title">{%trans 'Creating a public draw' %}   </span>
+                                <div role="presentation" class="divider"></div>
+                                <span id="choose" class="col-xs-4 subtitle done">1. {%trans 'Choose' %}</span>
+                                <span id="configure" class="col-xs-4 subtitle focus">2. {%trans 'Configure' %}</span>
+                                <span id="spread" class="col-xs-4 subtitle">3. {%trans 'Spread' %}</span>
+                            </div>
+                            <!--<a href="{% url 'index' %}" class="cancel fa fa-times fa-2x"></a><br>-->
+                        </div>
+                    {% endif %}
+                </div>
+                <!-- End Public Draw Info -->
+
                 {% block content %}
                     <p>Page to be filled.</p>
                 {% endblock content %}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -285,10 +285,10 @@
                     {% if is_public%}
                         <div class="info-public-draw">
                             <div class="help-text">
-                                <span class="col-xs-10 col-xs-offset-1 title">{%trans 'Creating a public draw' %}   </span>
+                                <span class="col-xs-12 col-sm-10 col-sm-offset-1 title">{%trans 'Creating a public draw' %}   </span>
                                 <div role="presentation" class="divider"></div>
-                                <span id="choose" class="col-xs-4 subtitle done">1. {%trans 'Choose' %}</span>
-                                <span id="configure" class="col-xs-4 subtitle focus">2. {%trans 'Configure' %}</span>
+                                <span id="choose" class="col-xs-4 subtitle focus">1. {%trans 'Choose' %}</span>
+                                <span id="configure" class="col-xs-4 subtitle">2. {%trans 'Configure' %}</span>
                                 <span id="spread" class="col-xs-4 subtitle">3. {%trans 'Spread' %}</span>
                             </div>
                             <!--<a href="{% url 'index' %}" class="cancel fa fa-times fa-2x"></a><br>-->

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -21,7 +21,7 @@
         $("textarea.autogrow").autoGrowInput({title:'{{ bom.title|default:bom.DEFAULT_TITLE }}',maxWidth: max_width,minWidth:30,comfortZone:30});
     };
 
-    // Autosize the first time
+    // Autosize the title box the first time
     autosize();
     $( window ).resize(function() {
         // Autosize when the window is resized
@@ -48,6 +48,7 @@
         $('#id_password').val($('#draw-password').val());
     });
 
+    // Setting up "Add to favourite" button
     $(this).find('#fav-loading').hide();
     $('#fav-button').click(function(){
         if ('{{ user.is_authenticated }}' == 'False'){
@@ -97,7 +98,7 @@
             shared_type_field.attr('value','Public');
         }
 
-
+        // Storing the level of restiction for the draw
 	    $('#save').click(function () {
 	        var mode = $('.slide-bar').attr('data-selected');
 	        if (mode == "invited"){
@@ -112,6 +113,21 @@
 				shared_type_field.attr('value','Public');
 	        }
 	    });
+
+        // By default, divs for "Spread" step are hidden
+        $('.step-spread').hide();
+
+        // Setting up button "Next"
+        $('#next').click(function() {
+            $('.step-configure').hide();
+            $('.step-spread').show();
+
+            // Showing status of the public draw configuration
+            $('.info-public-draw #configure').removeClass('focus');
+            $('.info-public-draw #configure').addClass('done');
+            $('.info-public-draw #spread').removeClass('done');
+            $('.info-public-draw #spread').addClass('focus');
+        });
     {% endif %}
 
     // Manages the slider to choose the level of restriction of the public draw
@@ -165,20 +181,28 @@
                 {% endfor  %}
                 <!-- Input Form -->
                 {% block input_form %}
-                {% crispy draw draw.helper %}
-                    <div class="col-xs-12 text-center">
-                        {% if is_public %}
-                            <div class="row btn-row">
-                                <button type="submit" name="try" class="btn btn-success btn-try">{% trans 'Try it!' %}</button>
+                    <div class="step-configure">
+                        {% crispy draw draw.helper %}
+                    </div>
+                    <div class="step-spread">
+                        <div class="public-draw-restriction col-xs-12 col-md-8 col-md-offset-2">
+                            <div class="col-xs-6">
+                                Who can access your draw?
                             </div>
-                            <div class="col-sm-8 col-sm-offset-2 btn-row">
-
-                                <a href="{% url 'index' %}" class="col-xs-6 btn btn-default btn-cancel">{% trans 'Cancel' %}</a>
-                                <button type="submit" name="next" class="col-xs-6 btn btn-primary btn-next">{% trans 'Next step' %}</button>
+                            <div class="col-xs-6">
+                                Everyone
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-xs-12 text-center">
+                        <!-- Buttons for 'Toss' or 'Try it!' -->
+                        {% if is_public %}
+                            <div class="row btn-row step-configure">
+                                <button type="submit" name="try" class="btn btn-success">{% trans 'Try it!' %}</button>
                             </div>
                         {% else %}
                             <div class="row btn-row">
-                                <button type="submit" name="toss" class="btn btn-success btn-toss"{%if not can_write%}disabled="disabled"{%endif%}>{% trans 'Toss' %}</button>
+                                <button type="submit" name="toss" class="btn btn-success"{%if not can_write%}disabled="disabled"{%endif%}>{% trans 'Toss' %}</button>
                             </div>
                             {%if not can_write and bom.owner%}
                                 <div class="alert alert-warning alert-dismissible" role="alert">
@@ -187,6 +211,15 @@
                                 </div>
                             {%endif%}
                         {% endif %}
+
+                        <!-- Buttons for 'Next step' and 'Cancel' public draw creation -->
+                        {% if is_public %}
+                            <div class="col-sm-8 col-sm-offset-2 btn-row">
+                                <a href="{% url 'index' %}" class="col-xs-6 btn btn-default">{% trans 'Cancel' %}</a>
+                                <a id="next" name="next" class="col-xs-6 btn btn-primary step-configure">{% trans 'Next step' %}</a>
+                                <button type="submit" name="next" class="col-xs-6 btn btn-primary step-spread">{% trans 'Publish it' %}</button>
+                            </div>
+                        {% endif %}
                     </div>
                 {% endblock input_form %}
             </div>
@@ -194,7 +227,7 @@
         </form>
         <!-- End Input Form -->
         <!-- Results -->
-        <div class="col-sm-8 col-sm-offset-2">
+        <div class="col-sm-8 col-sm-offset-2 step-configure">
             <div class="row text-center accordion">
             {% for result in bom.results reversed %}
             {% with result.items as results%}

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -83,6 +83,12 @@
     });
 
     {% if is_public  or bom.shared_type != "None" %}
+        // Showing status of the public draw configuration
+        $('.info-public-draw #choose').removeClass('focus');
+        $('.info-public-draw #choose').addClass('done');
+        $('.info-public-draw #configure').removeClass('done');
+        $('.info-public-draw #configure').addClass('focus');
+
 	    var shared_type_field = $('input[name=shared_type]');
 
     	//default is None, set to Public by default if it is a new public draw

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -115,17 +115,6 @@
 {% endblock extra_jq_ready %}
 {% block content %}
     <div class="row">
-        <!-- Public Draw Info -->
-        {% if is_public %}
-            <div class="info-public-draw">
-                <div class="help-text">
-                    <span class="title">{%trans 'Creating a public draw' %}   </span>
-                    <span class="subtitle">{%trans 'Set it up' %}</span>
-                </div>
-                <a href="{% url 'index' %}" class="cancel fa fa-times fa-2x"></a><br>
-            </div>
-        {% endif %}
-	    <!-- End Public Draw Info -->
         <form class="clearfix" method="post">
             <!-- Draw Heading -->
             <div class="clearfix draw-heading">

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -168,10 +168,18 @@
                 {% crispy draw draw.helper %}
                     <div class="col-xs-12 text-center">
                         {% if is_public %}
-                            <button type="submit" name="try" class="btn btn-success btn-try">{% trans 'Try it!' %}</button>
-                            <button type="submit" name="next" class="btn btn-primary btn-next">{% trans 'Next' %}</button>
+                            <div class="row btn-row">
+                                <button type="submit" name="try" class="btn btn-success btn-try">{% trans 'Try it!' %}</button>
+                            </div>
+                            <div class="col-sm-8 col-sm-offset-2 btn-row">
+
+                                <a href="{% url 'index' %}" class="col-xs-6 btn btn-default btn-cancel">{% trans 'Cancel' %}</a>
+                                <button type="submit" name="next" class="col-xs-6 btn btn-primary btn-next">{% trans 'Next step' %}</button>
+                            </div>
                         {% else %}
-                            <button type="submit" name="toss" class="btn btn-success btn-toss"{%if not can_write%}disabled="disabled"{%endif%}>{% trans 'Toss' %}</button>
+                            <div class="row btn-row">
+                                <button type="submit" name="toss" class="btn btn-success btn-toss"{%if not can_write%}disabled="disabled"{%endif%}>{% trans 'Toss' %}</button>
+                            </div>
                             {%if not can_write and bom.owner%}
                                 <div class="alert alert-warning alert-dismissible" role="alert">
                                   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -29,19 +29,6 @@
 
 {% endblock extra_jq_ready %}
 {% block content %}
-	<div class="row">
-    <!-- Public Draw Info -->
-	{% if is_public%}
-	    <div class="info-public-draw">
-	        <div class="help-text">
-	            <span class="title">{%trans 'Creating a public draw' %}   </span>
-                <span class="subtitle">{%trans 'Select the type of draw' %}</span>
-	        </div>
-            <a href="{% url 'index' %}" class="cancel fa fa-times fa-2x"></a><br>
-	    </div>
-	{% endif %}
-    <!-- End Public Draw Info -->
-	</div>
     <div class="container-draws row">
         <div class="col-sm-6">
             <a class="draw-link" href="{% url 'draw' draw_type='coin' publish=is_public %}">


### PR DESCRIPTION
Added breadcrum to assist the process of creating a public draw.

Still need a couple of changes:
1) So far, the step between "configure" and "spread" is done only by JS. We have to send the info to the server so the draw is validated right after clicking "Next" button (before inviting people). Then we can also send a variable stating which is the step of the process of creating a public draw we are in and so we'll avoid to change the layout using JS.

2) When the public draw is being configured, the user has to be able to come back to de "Choose" step and select another kind of draw, but it should keep as many details as possible from the previous draw (i.e. the list of invited users, number of results...)