### PR TITLE
Bug Fix #97 : Numbers of results cant be changed

### DIFF
--- a/web/views.py
+++ b/web/views.py
@@ -79,7 +79,8 @@ def find_previous_version(curr_draw):
     logger.info("There is a previous version of this draw in the DB {0}".format(prev_draw._id, k))
 
     #updatable fields of prev draw
-    for k in ('password', 'shared_type', 'title'):
+    UPDATE_FIELDS=('password', 'shared_type', 'title', 'users', 'number_of_results')
+    for k in UPDATE_FIELDS:
         prev_draw.__dict__[k] = curr_draw.__dict__[k]
     return prev_draw
 


### PR DESCRIPTION
 - Add list of properties to update when a prev draw is taken.
 - Included missing elements (number_of_results, users)

This list represents the list of items that can be updated from draw to
draw withoud considering it a change. The items in this list but not the
prev one are items that can be modified but that the changes should be
ignored.

Close Bug #97