### PR TITLE
Implement settings panel for a published draw

### DIFF
--- a/static/css/eas-draw-base.css
+++ b/static/css/eas-draw-base.css
@@ -62,7 +62,7 @@ a.fa:focus {
     height: auto;
 }
 
-.draw-heading .add-password {
+.draw-heading .access-level {
     color: #6F6F6F;
 }
 

--- a/static/css/eas-draw-base.css
+++ b/static/css/eas-draw-base.css
@@ -194,7 +194,9 @@ a.fa:focus {
     text-align: right;
 }
 
-
+.settings-option {
+    cursor: pointer;
+}
 
 /***** INDIVIDUAL DRAWS *****/
 /* Makes the text be inline with the checkbox */

--- a/static/js/public_draw_manager.js
+++ b/static/js/public_draw_manager.js
@@ -76,7 +76,8 @@ public_draw_manager.show_configure = function () {
 public_draw_manager.settings = function () {
 
     $('#edit-draw').click(function() {
-        // Do something
+        $('#settings-general').addClass("hide");
+        $('#settings-edit-draw').removeClass("hide");
     });
 
 }

--- a/static/js/public_draw_manager.js
+++ b/static/js/public_draw_manager.js
@@ -56,23 +56,6 @@ public_draw_manager.prepare_privacy_selection = function (){
     });
 }
 
-// Initialize the interface for the step "Spread"
-public_draw_manager.show_spread = function () {
-    // Hide the part of the form related with configuration (it contains information)
-    $('.step-configure').hide();
-
-    //Initialize the UI to select the level of privacy for the draw
-    public_draw_manager.prepare_privacy_selection();
-
-    // Initialize input to submit emails to be shown as a tokenField
-    $('#public-draw-invite #emails').tokenfield({createTokensOnBlur:true, delimiter: [',',' '], minWidth: 100});
-}
-
-// Initialize the interface for the step "Configure"
-public_draw_manager.show_configure = function () {
-    $('.step-spread').hide();
-}
-
 public_draw_manager.settings = function () {
 
     $('li#edit-draw').click(function() {
@@ -85,6 +68,11 @@ public_draw_manager.settings = function () {
         $('#settings-invite').removeClass("hide");
     });
 
+    $('li#privacy').click(function() {
+        $('#settings-general').addClass("hide");
+        $('#settings-privacy').removeClass("hide");
+    });
+
     $('.btn-settings-back').click(function() {
         $('#settings-general').removeClass("hide");
         $('.settings-submenu').addClass("hide");
@@ -93,16 +81,22 @@ public_draw_manager.settings = function () {
 }
 // Initialize the interface for a public draw
 public_draw_manager.setup = function(current_step){
-
-    public_draw_manager.update_breadcrumb(current_step);
     public_draw_manager.set_submition_type(current_step);
+    //Initialize the UI to select the level of privacy for the draw
+    public_draw_manager.prepare_privacy_selection();
+    // Initialize input to submit emails to be shown as a tokenField
+    $('#public-draw-invite #emails').tokenfield({createTokensOnBlur:true, delimiter: [',',' '], minWidth: 100});
 
     if (current_step == ""){
         // If the draw has already been published
         public_draw_manager.settings();
-    } else if (current_step == "spread"){
-        public_draw_manager.show_spread();
-    } else if (current_step == "configure"){
-        public_draw_manager.show_configure();
+    } else{
+        // If the the user is creating the draw
+        public_draw_manager.update_breadcrumb(current_step);
+        if (current_step == "spread"){
+            $('.step-configure').hide();
+        } else if (current_step == "configure"){
+            $('.step-spread').hide();
+        }
     }
 }

--- a/static/js/public_draw_manager.js
+++ b/static/js/public_draw_manager.js
@@ -80,6 +80,11 @@ public_draw_manager.settings = function () {
         $('#settings-edit-draw').removeClass("hide");
     });
 
+    $('.btn-settings-back').click(function() {
+        $('#settings-general').removeClass("hide");
+        $('.settings-submenu').addClass("hide");
+    });
+
 }
 // Initialize the interface for a public draw
 public_draw_manager.setup = function(current_step){

--- a/static/js/public_draw_manager.js
+++ b/static/js/public_draw_manager.js
@@ -75,9 +75,14 @@ public_draw_manager.show_configure = function () {
 
 public_draw_manager.settings = function () {
 
-    $('#edit-draw').click(function() {
+    $('li#edit-draw').click(function() {
         $('#settings-general').addClass("hide");
         $('#settings-edit-draw').removeClass("hide");
+    });
+
+    $('li#invite').click(function() {
+        $('#settings-general').addClass("hide");
+        $('#settings-invite').removeClass("hide");
     });
 
     $('.btn-settings-back').click(function() {

--- a/static/js/public_draw_manager.js
+++ b/static/js/public_draw_manager.js
@@ -73,13 +73,23 @@ public_draw_manager.show_configure = function () {
     $('.step-spread').hide();
 }
 
+public_draw_manager.settings = function () {
+
+    $('#edit-draw').click(function() {
+        // Do something
+    });
+
+}
 // Initialize the interface for a public draw
 public_draw_manager.setup = function(current_step){
 
     public_draw_manager.update_breadcrumb(current_step);
     public_draw_manager.set_submition_type(current_step);
 
-    if (current_step == "spread"){
+    if (current_step == ""){
+        // If the draw has already been published
+        public_draw_manager.settings();
+    } else if (current_step == "spread"){
         public_draw_manager.show_spread();
     } else if (current_step == "configure"){
         public_draw_manager.show_configure();

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -280,11 +280,11 @@
                     </div>
                     <div class="modal-body">
                         <ul id="" class="list-group">
-                            <li id="edit-draw" class="list-group-item">Edit draw configuration</li>
-                            <li id="invite" class="list-group-item">Invite people</li>
-                            <li id="privacy" class="list-group-item">Who can access your draw</li>
-                            <li class="list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>
-                            <li class="list-group-item"><input type="checkbox"> Enable chat</li>
+                            <li id="edit-draw" class="settings-option list-group-item">Edit draw configuration</li>
+                            <li id="invite" class="settings-option list-group-item">Invite people</li>
+                            <li id="privacy" class="settings-option list-group-item">Who can access your draw</li>
+                            <li class="settings-option list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>
+                            <li class="settings-option list-group-item"><input type="checkbox"> Enable chat</li>
                         </ul>
                     </div>
                     <div class="modal-footer">

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -255,89 +255,91 @@
     </div>
 
     {% if is_public %}
-        {# Hover panel to change the lever of restriction of the public draw (when setting it up) #}
-        <div id="access-level" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title">{% trans "Restict the access to your draw" %}</h4>
-            </div>
-            <div class="modal-body">
-                {% include "public-draw-privacy.html" %}
-            </div>
-            <div class="modal-footer">
-                <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
-                <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
-            </div>
-        </div>
-
-        {# Hover panel to show the settings of the public draw (when it is published) #}
-        <div id="public-draw-settings" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
-            <div id="settings-general">
+        {% if public_draw_step %} {# If user is creating the draw #}
+            {# Hover panel to change the lever of restriction of the public draw (when setting it up) #}
+            <div id="access-level" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">{% trans "Public draw settings" %}</h4>
+                    <h4 class="modal-title">{% trans "Restict the access to your draw" %}</h4>
                 </div>
                 <div class="modal-body">
-                    <ul id="" class="list-group">
-                        <li id="edit-draw" class="list-group-item">Edit draw configuration</li>
-                        <li id="invite" class="list-group-item">Invite people</li>
-                        <li class="list-group-item">Who can access your draw</li>
-                        <li class="list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>
-                        <li class="list-group-item"><input type="checkbox"> Enable chat</li>
-                    </ul>
+                    {% include "public-draw-privacy.html" %}
                 </div>
                 <div class="modal-footer">
                     <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
                     <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
                 </div>
             </div>
-            <div id="settings-edit-draw" class="settings-submenu hide">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">{% trans "Edit draw configuration" %}</h4>
+        {% else%}{# If the draw is already published #}
+            {# Hover panel to show the settings of the public draw (when it is published) #}
+            <div id="public-draw-settings" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
+                <div id="settings-general">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h4 class="modal-title">{% trans "Public draw settings" %}</h4>
+                    </div>
+                    <div class="modal-body">
+                        <ul id="" class="list-group">
+                            <li id="edit-draw" class="list-group-item">Edit draw configuration</li>
+                            <li id="invite" class="list-group-item">Invite people</li>
+                            <li id="privacy" class="list-group-item">Who can access your draw</li>
+                            <li class="list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>
+                            <li class="list-group-item"><input type="checkbox"> Enable chat</li>
+                        </ul>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
+                        <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
+                    </div>
                 </div>
-                <div class="modal-body">
-                    If you modify the draw's configuration the spectator will be notified about these changes. Are you sure you want to continue?
+                <div id="settings-edit-draw" class="settings-submenu hide">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h4 class="modal-title">{% trans "Edit draw configuration" %}</h4>
+                    </div>
+                    <div class="modal-body">
+                        If you modify the draw's configuration the spectator will be notified about these changes. Are you sure you want to continue?
+                    </div>
+                    <div class="modal-footer">
+                        <a class="btn btn-default btn-settings-back">Back</a>
+                        <a id="btn-edit-draw" class="btn btn-warning">Edit draw</a>
+                    </div>
                 </div>
-                <div class="modal-footer">
-                    <a class="btn btn-default btn-settings-back">Back</a>
-                    <a id="btn-edit-draw" class="btn btn-warning">Edit draw</a>
+                <div id="settings-invite" class="settings-submenu hide">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h4 class="modal-title">{% trans "Invite people" %}</h4>
+                    </div>
+                    <div class="modal-body">
+                        <p>An invitation will arrive to the emails you introduce below</p>
+                        <input type="text" id="emails" name="invite-emails" class="form-control" placeholder="Type the emails here...">
+                        <a class="btn btn-info send-emails">Send emails</a>
+                        <p>OR</p>
+                        <p data-toggle="tooltip" data-placement="top" title="Feature coming soon">Share the link to the draw:
+                            <a><strike>http://127.0.0.1:8000/draw/5504d71b78332720c439f120</strike></a>
+                        </p>
+                    </div>
+                    <div class="modal-footer">
+                        <a class="btn btn-default btn-settings-back">Back</a>
+                        <button type="button" data-dismiss="modal" class="btn btn-default">Close</button>
+                    </div>
                 </div>
-            </div>
-            <div id="settings-invite" class="settings-submenu hide">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">{% trans "Invite people" %}</h4>
-                </div>
-                <div class="modal-body">
-                    <p>An invitation will arrive to the emails you introduce below</p>
-                    <input type="text" id="emails" name="invite-emails" class="form-control" placeholder="Type the emails here...">
-                    <a class="btn btn-info send-emails">Send emails</a>
-                    <p>OR</p>
-                    <p data-toggle="tooltip" data-placement="top" title="Feature coming soon">Share the link to the draw:
-                        <a><strike>http://127.0.0.1:8000/draw/5504d71b78332720c439f120</strike></a>
-                    </p>
-                </div>
-                <div class="modal-footer">
-                    <a class="btn btn-default btn-settings-back">Back</a>
-                    <button type="button" data-dismiss="modal" class="btn btn-default">Close</button>
-                </div>
-            </div>
 
-            <div id="settings-privacy" class="settings-submenu hide">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">{% trans "Restrict the access to your draw" %}</h4>
-                </div>
-                <div class="modal-body">
-                    {% include "public-draw-privacy.html" %}
-                </div>
-                <div class="modal-footer">
-                    <a class="btn btn-default btn-settings-back">Back</a>
-                    <a id="save" data-dismiss="modal" class="btn btn-primary">Save</a>
+                <div id="settings-privacy" class="settings-submenu hide">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h4 class="modal-title">{% trans "Restrict the access to your draw" %}</h4>
+                    </div>
+                    <div class="modal-body">
+                        {% include "public-draw-privacy.html" %}
+                    </div>
+                    <div class="modal-footer">
+                        <a class="btn btn-default btn-settings-back">Back</a>
+                        <a id="save" data-dismiss="modal" class="btn btn-primary">Save</a>
+                    </div>
                 </div>
             </div>
-        </div>
+        {% endif %}
     {% endif %}
 {% endblock %}
 

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -258,54 +258,54 @@
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
             <h4 class="modal-title">{% trans "Restict the access to your draw" %}</h4>
-            </div>
-                <div class="modal-body">
-                    <div class="row">
-                        <div class="col-md-12">
-                            {% trans "Who do you want to access the draw?" %}
-                            <div class="col-sm-8 col-sm-offset-2 text-center">
-                                <div id="restriction-headings">
-                                    <div id="restriction-everyone" class="col-xs-3">{% trans "Everyone" %}</div>
-                                    <div id="restriction-password" class="col-xs-6">{% trans "With password or invitation" %}</div>
-                                    <div id="restriction-invited" class="col-xs-3">{% trans "Only with invitation" %}</div>
-                                </div>
-                                <div class="col-xs-8 col-sm-10 col-xs-offset-2 col-sm-offset-1 slide-bar-container">
-                                    <div data-selected="everyone" class="slide-bar ui-widget-content">
-                                        <div class="slider-tick" style="left: 0%"></div>
-                                        <div class="slider-tick" style="left: 50%"></div>
-                                        <div class="slider-tick" style="left: 100%"></div>
-                                        <div class="slide-selector" ></div>
-                                    </div>
-                                </div>
+        </div>
+        <div class="modal-body">
+            <div class="row">
+                <div class="col-md-12">
+                    {% trans "Who do you want to access the draw?" %}
+                    <div class="col-sm-8 col-sm-offset-2 text-center">
+                        <div id="restriction-headings">
+                            <div id="restriction-everyone" class="col-xs-3">{% trans "Everyone" %}</div>
+                            <div id="restriction-password" class="col-xs-6">{% trans "With password or invitation" %}</div>
+                            <div id="restriction-invited" class="col-xs-3">{% trans "Only with invitation" %}</div>
+                        </div>
+                        <div class="col-xs-8 col-sm-10 col-xs-offset-2 col-sm-offset-1 slide-bar-container">
+                            <div data-selected="everyone" class="slide-bar ui-widget-content">
+                                <div class="slider-tick" style="left: 0%"></div>
+                                <div class="slider-tick" style="left: 50%"></div>
+                                <div class="slider-tick" style="left: 100%"></div>
+                                <div class="slide-selector" ></div>
                             </div>
-                            <div id="restriction-extra" class="col-xs-12">
-                                <div id="extra-everyone" class="col-xs-12">
-                                    {% trans "Everyone will be able to access the draw." %}
-                                    <div class="alert alert-info" role="alert">
-                                        {% trans "Tip: Use this mode for informal and fast draws. Neither invitation nor password will be required!" %}
-                                    </div>
-                                </div>
-                                <div id="extra-password" class="col-xs-12">
-                                    {% trans "Only those who know the password will be able to access the draw." %}
-                                    <div class="col-xs-12 input-group">
-                                        <span class="input-group-addon"><i class="fa fa-lock"></i></span>
-                                        <input id="draw-password" type="password" class="form-control has-clear" name="password" placeholder="Password">
-                                    </div>
-                                    <div class="alert alert-info" role="alert">
-                                        {% trans "Tip: You don't know exactly who is going to join the draw but still want some restriction? This is your draw!" %}
-                                    </div>
-                                </div>
-                                <div id="extra-invited" class="col-xs-12">
-                                    {% trans "You will be able to invite people by email when the draw is created." %}
-                                    <div class="alert alert-info" role="alert">
-                                        {% trans "Tip: Use this mode for small/medium groups where you know well who do you want to join the draw." %}
-                                    </div>
-                                </div>
+                        </div>
+                    </div>
+                    <div id="restriction-extra" class="col-xs-12">
+                        <div id="extra-everyone" class="col-xs-12">
+                            {% trans "Everyone will be able to access the draw." %}
+                            <div class="alert alert-info" role="alert">
+                                {% trans "Tip: Use this mode for informal and fast draws. Neither invitation nor password will be required!" %}
+                            </div>
+                        </div>
+                        <div id="extra-password" class="col-xs-12">
+                            {% trans "Only those who know the password will be able to access the draw." %}
+                            <div class="col-xs-12 input-group">
+                                <span class="input-group-addon"><i class="fa fa-lock"></i></span>
+                                <input id="draw-password" type="password" class="form-control has-clear" name="password" placeholder="Password">
+                            </div>
+                            <div class="alert alert-info" role="alert">
+                                {% trans "Tip: You don't know exactly who is going to join the draw but still want some restriction? This is your draw!" %}
+                            </div>
+                        </div>
+                        <div id="extra-invited" class="col-xs-12">
+                            {% trans "You will be able to invite people by email when the draw is created." %}
+                            <div class="alert alert-info" role="alert">
+                                {% trans "Tip: Use this mode for small/medium groups where you know well who do you want to join the draw." %}
                             </div>
                         </div>
                     </div>
                 </div>
-            <div class="modal-footer">
+            </div>
+        </div>
+        <div class="modal-footer">
             <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
             <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
         </div>

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -353,7 +353,17 @@
                     <h4 class="modal-title">{% trans "Invite people" %}</h4>
                 </div>
                 <div class="modal-body">
-                    // To be filled
+                    <p>An invitation will arrive to the emails you introduce below</p>
+                    <input type="text" id="emails" name="invite-emails" class="form-control" placeholder="Type the emails here...">
+                    <a class="btn btn-info send-emails">Send emails</a>
+                    <p>OR</p>
+                    <p data-toggle="tooltip" data-placement="top" title="Feature coming soon">Share the link to the draw:
+                        <a><strike>http://127.0.0.1:8000/draw/5504d71b78332720c439f120</strike></a>
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <a class="btn btn-default btn-settings-back">Back</a>
+                    <button type="button" data-dismiss="modal" class="btn btn-default">Close</button>
                 </div>
             </div>
         </div>

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -323,7 +323,7 @@
                 <div class="modal-body">
                     <ul id="" class="list-group">
                         <li id="edit-draw" class="list-group-item">Edit draw configuration</li>
-                        <li class="list-group-item">Invite people</li>
+                        <li id="invite" class="list-group-item">Invite people</li>
                         <li class="list-group-item">Who can access your draw</li>
                         <li class="list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>
                         <li class="list-group-item"><input type="checkbox"> Enable chat</li>

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -323,6 +323,20 @@
                     <button type="button" data-dismiss="modal" class="btn btn-default">Close</button>
                 </div>
             </div>
+
+            <div id="settings-privacy" class="settings-submenu hide">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title">{% trans "Restrict the access to your draw" %}</h4>
+                </div>
+                <div class="modal-body">
+                    {% include "public-draw-privacy.html" %}
+                </div>
+                <div class="modal-footer">
+                    <a class="btn btn-default btn-settings-back">Back</a>
+                    <a id="save" data-dismiss="modal" class="btn btn-primary">Save</a>
+                </div>
+            </div>
         </div>
     {% endif %}
 {% endblock %}

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -262,50 +262,7 @@
                 <h4 class="modal-title">{% trans "Restict the access to your draw" %}</h4>
             </div>
             <div class="modal-body">
-                <div class="row">
-                    <div class="col-md-12">
-                        {% trans "Who do you want to access the draw?" %}
-                        <div class="col-sm-8 col-sm-offset-2 text-center">
-                            <div id="restriction-headings">
-                                <div id="restriction-everyone" class="col-xs-3">{% trans "Everyone" %}</div>
-                                <div id="restriction-password" class="col-xs-6">{% trans "With password or invitation" %}</div>
-                                <div id="restriction-invited" class="col-xs-3">{% trans "Only with invitation" %}</div>
-                            </div>
-                            <div class="col-xs-8 col-sm-10 col-xs-offset-2 col-sm-offset-1 slide-bar-container">
-                                <div data-selected="everyone" class="slide-bar ui-widget-content">
-                                    <div class="slider-tick" style="left: 0%"></div>
-                                    <div class="slider-tick" style="left: 50%"></div>
-                                    <div class="slider-tick" style="left: 100%"></div>
-                                    <div class="slide-selector" ></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div id="restriction-extra" class="col-xs-12">
-                            <div id="extra-everyone" class="col-xs-12">
-                                {% trans "Everyone will be able to access the draw." %}
-                                <div class="alert alert-info" role="alert">
-                                    {% trans "Tip: Use this mode for informal and fast draws. Neither invitation nor password will be required!" %}
-                                </div>
-                            </div>
-                            <div id="extra-password" class="col-xs-12">
-                                {% trans "Only those who know the password will be able to access the draw." %}
-                                <div class="col-xs-12 input-group">
-                                    <span class="input-group-addon"><i class="fa fa-lock"></i></span>
-                                    <input id="draw-password" type="password" class="form-control has-clear" name="password" placeholder="Password">
-                                </div>
-                                <div class="alert alert-info" role="alert">
-                                    {% trans "Tip: You don't know exactly who is going to join the draw but still want some restriction? This is your draw!" %}
-                                </div>
-                            </div>
-                            <div id="extra-invited" class="col-xs-12">
-                                {% trans "You will be able to invite people by email when the draw is created." %}
-                                <div class="alert alert-info" role="alert">
-                                    {% trans "Tip: Use this mode for small/medium groups where you know well who do you want to join the draw." %}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                {% include "public-draw-privacy.html" %}
             </div>
             <div class="modal-footer">
                 <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -254,62 +254,65 @@
         <!-- End Results -->
     </div>
 
-    <div id="access-level" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
-        <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-            <h4 class="modal-title">{% trans "Restict the access to your draw" %}</h4>
-        </div>
-        <div class="modal-body">
-            <div class="row">
-                <div class="col-md-12">
-                    {% trans "Who do you want to access the draw?" %}
-                    <div class="col-sm-8 col-sm-offset-2 text-center">
-                        <div id="restriction-headings">
-                            <div id="restriction-everyone" class="col-xs-3">{% trans "Everyone" %}</div>
-                            <div id="restriction-password" class="col-xs-6">{% trans "With password or invitation" %}</div>
-                            <div id="restriction-invited" class="col-xs-3">{% trans "Only with invitation" %}</div>
-                        </div>
-                        <div class="col-xs-8 col-sm-10 col-xs-offset-2 col-sm-offset-1 slide-bar-container">
-                            <div data-selected="everyone" class="slide-bar ui-widget-content">
-                                <div class="slider-tick" style="left: 0%"></div>
-                                <div class="slider-tick" style="left: 50%"></div>
-                                <div class="slider-tick" style="left: 100%"></div>
-                                <div class="slide-selector" ></div>
+    {% if is_public %}
+        {# Hover panel to change the lever of restriction of the public draw (when setting it up) #}
+        <div id="access-level" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">{% trans "Restict the access to your draw" %}</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="col-md-12">
+                        {% trans "Who do you want to access the draw?" %}
+                        <div class="col-sm-8 col-sm-offset-2 text-center">
+                            <div id="restriction-headings">
+                                <div id="restriction-everyone" class="col-xs-3">{% trans "Everyone" %}</div>
+                                <div id="restriction-password" class="col-xs-6">{% trans "With password or invitation" %}</div>
+                                <div id="restriction-invited" class="col-xs-3">{% trans "Only with invitation" %}</div>
+                            </div>
+                            <div class="col-xs-8 col-sm-10 col-xs-offset-2 col-sm-offset-1 slide-bar-container">
+                                <div data-selected="everyone" class="slide-bar ui-widget-content">
+                                    <div class="slider-tick" style="left: 0%"></div>
+                                    <div class="slider-tick" style="left: 50%"></div>
+                                    <div class="slider-tick" style="left: 100%"></div>
+                                    <div class="slide-selector" ></div>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div id="restriction-extra" class="col-xs-12">
-                        <div id="extra-everyone" class="col-xs-12">
-                            {% trans "Everyone will be able to access the draw." %}
-                            <div class="alert alert-info" role="alert">
-                                {% trans "Tip: Use this mode for informal and fast draws. Neither invitation nor password will be required!" %}
+                        <div id="restriction-extra" class="col-xs-12">
+                            <div id="extra-everyone" class="col-xs-12">
+                                {% trans "Everyone will be able to access the draw." %}
+                                <div class="alert alert-info" role="alert">
+                                    {% trans "Tip: Use this mode for informal and fast draws. Neither invitation nor password will be required!" %}
+                                </div>
                             </div>
-                        </div>
-                        <div id="extra-password" class="col-xs-12">
-                            {% trans "Only those who know the password will be able to access the draw." %}
-                            <div class="col-xs-12 input-group">
-                                <span class="input-group-addon"><i class="fa fa-lock"></i></span>
-                                <input id="draw-password" type="password" class="form-control has-clear" name="password" placeholder="Password">
+                            <div id="extra-password" class="col-xs-12">
+                                {% trans "Only those who know the password will be able to access the draw." %}
+                                <div class="col-xs-12 input-group">
+                                    <span class="input-group-addon"><i class="fa fa-lock"></i></span>
+                                    <input id="draw-password" type="password" class="form-control has-clear" name="password" placeholder="Password">
+                                </div>
+                                <div class="alert alert-info" role="alert">
+                                    {% trans "Tip: You don't know exactly who is going to join the draw but still want some restriction? This is your draw!" %}
+                                </div>
                             </div>
-                            <div class="alert alert-info" role="alert">
-                                {% trans "Tip: You don't know exactly who is going to join the draw but still want some restriction? This is your draw!" %}
-                            </div>
-                        </div>
-                        <div id="extra-invited" class="col-xs-12">
-                            {% trans "You will be able to invite people by email when the draw is created." %}
-                            <div class="alert alert-info" role="alert">
-                                {% trans "Tip: Use this mode for small/medium groups where you know well who do you want to join the draw." %}
+                            <div id="extra-invited" class="col-xs-12">
+                                {% trans "You will be able to invite people by email when the draw is created." %}
+                                <div class="alert alert-info" role="alert">
+                                    {% trans "Tip: Use this mode for small/medium groups where you know well who do you want to join the draw." %}
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
+            <div class="modal-footer">
+                <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
+                <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
+            </div>
         </div>
-        <div class="modal-footer">
-            <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
-            <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
-        </div>
-    </div>
+    {% endif %}
 {% endblock %}
 
 

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -133,7 +133,7 @@
                                     <p class="h4">Who can access your draw? </p>
                                 </div>
                                 <div class="col-xs-6 text-center">
-                                    <a data-toggle="modal" href="#modal" class="add-password">
+                                    <a data-toggle="modal" href="#access-level" class="access-level">
                                         <span class="fa fa-unlock fa-2x"></span> <div id="public-mode-selected"> Everyone </div>
 
                                     </a>
@@ -254,7 +254,7 @@
         <!-- End Results -->
     </div>
 
-    <div id="modal" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
+    <div id="access-level" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
             <h4 class="modal-title">{% trans "Restict the access to your draw" %}</h4>

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -321,7 +321,7 @@
             </div>
             <div class="modal-body">
                 <ul class="list-group">
-                    <li class="list-group-item">Edit draw configuration</li>
+                    <li id="edit-draw" class="list-group-item">Edit draw configuration</li>
                     <li class="list-group-item">Invite people</li>
                     <li class="list-group-item">Who can access your draw</li>
                     <li class="list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -315,22 +315,46 @@
 
         {# Hover panel to show the settings of the public draw (when it is published) #}
         <div id="public-draw-settings" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title">{% trans "Public draw settings" %}</h4>
+            <div id="settings-general">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title">{% trans "Public draw settings" %}</h4>
+                </div>
+                <div class="modal-body">
+                    <ul id="" class="list-group">
+                        <li id="edit-draw" class="list-group-item">Edit draw configuration</li>
+                        <li class="list-group-item">Invite people</li>
+                        <li class="list-group-item">Who can access your draw</li>
+                        <li class="list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>
+                        <li class="list-group-item"><input type="checkbox"> Enable chat</li>
+                    </ul>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
+                    <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
+                </div>
             </div>
-            <div class="modal-body">
-                <ul class="list-group">
-                    <li id="edit-draw" class="list-group-item">Edit draw configuration</li>
-                    <li class="list-group-item">Invite people</li>
-                    <li class="list-group-item">Who can access your draw</li>
-                    <li class="list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>
-                    <li class="list-group-item"><input type="checkbox"> Enable chat</li>
-                </ul>
+            <div id="settings-edit-draw" class="settings-submenu hide">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title">{% trans "Edit draw configuration" %}</h4>
+                </div>
+                <div class="modal-body">
+                    If you modify the draw's configuration the spectator will be notified about these changes. Are you sure you want to continue?
+                </div>
+                <div class="modal-footer">
+                    <a class="btn btn-default">Back</a>
+                    <a id="btn-edit-draw" class="btn btn-warning">Edit draw</a>
+                </div>
             </div>
-            <div class="modal-footer">
-                <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
-                <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
+            <div id="settings-invite" class="settings-submenu hide">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title">{% trans "Invite people" %}</h4>
+                </div>
+                <div class="modal-body">
+                    // To be filled
+                </div>
             </div>
         </div>
     {% endif %}

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -266,8 +266,8 @@
                     {% include "public-draw-privacy.html" %}
                 </div>
                 <div class="modal-footer">
-                    <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
-                    <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
+                    <button type="button" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</button>
+                    <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">{% trans "Save" %}</button>
                 </div>
             </div>
         {% else%}{# If the draw is already published #}
@@ -280,16 +280,16 @@
                     </div>
                     <div class="modal-body">
                         <ul id="" class="list-group">
-                            <li id="edit-draw" class="settings-option list-group-item">Edit draw configuration</li>
-                            <li id="invite" class="settings-option list-group-item">Invite people</li>
-                            <li id="privacy" class="settings-option list-group-item">Who can access your draw</li>
-                            <li class="settings-option list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>
-                            <li class="settings-option list-group-item"><input type="checkbox"> Enable chat</li>
+                            <li id="edit-draw" class="settings-option list-group-item">{% trans "Edit draw configuration" %}</li>
+                            <li id="invite" class="settings-option list-group-item">{% trans "Invite people" %}</li>
+                            <li id="privacy" class="settings-option list-group-item">{% trans "Who can access your draw" %}</li>
+                            <li class="settings-option list-group-item"><input type="checkbox">{% trans "Show the draw in 'Recently created'" %}</li>
+                            <li class="settings-option list-group-item"><input type="checkbox">{% trans "Enable chat" %}</li>
                         </ul>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
-                        <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
+                        <button type="button" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</button>
+                        <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">{% trans "Save" %}</button>
                     </div>
                 </div>
                 <div id="settings-edit-draw" class="settings-submenu hide">
@@ -298,11 +298,11 @@
                         <h4 class="modal-title">{% trans "Edit draw configuration" %}</h4>
                     </div>
                     <div class="modal-body">
-                        If you modify the draw's configuration the spectator will be notified about these changes. Are you sure you want to continue?
+                        {% trans "If you modify the draw's configuration the spectator will be notified about these changes. Are you sure you want to continue?" %}
                     </div>
                     <div class="modal-footer">
-                        <a class="btn btn-default btn-settings-back">Back</a>
-                        <a id="btn-edit-draw" class="btn btn-warning">Edit draw</a>
+                        <a class="btn btn-default btn-settings-back">{% trans "Back" %}</a>
+                        <a id="btn-edit-draw" class="btn btn-warning">{% trans "Edit draw" %}</a>
                     </div>
                 </div>
                 <div id="settings-invite" class="settings-submenu hide">
@@ -311,17 +311,17 @@
                         <h4 class="modal-title">{% trans "Invite people" %}</h4>
                     </div>
                     <div class="modal-body">
-                        <p>An invitation will arrive to the emails you introduce below</p>
+                        <p>{% trans "An invitation will arrive to the emails you introduce below" %}</p>
                         <input type="text" id="emails" name="invite-emails" class="form-control" placeholder="Type the emails here...">
-                        <a class="btn btn-info send-emails">Send emails</a>
-                        <p>OR</p>
-                        <p data-toggle="tooltip" data-placement="top" title="Feature coming soon">Share the link to the draw:
+                        <a class="btn btn-info send-emails">{% trans "Send emails" %}</a>
+                        <p>{% trans "OR" %}</p>
+                        <p data-toggle="tooltip" data-placement="top" title="Feature coming soon">{% trans "Share the link to the draw:" %}
                             <a><strike>http://127.0.0.1:8000/draw/5504d71b78332720c439f120</strike></a>
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <a class="btn btn-default btn-settings-back">Back</a>
-                        <button type="button" data-dismiss="modal" class="btn btn-default">Close</button>
+                        <a class="btn btn-default btn-settings-back">{% trans "Back" %}</a>
+                        <button type="button" data-dismiss="modal" class="btn btn-default">{% trans "Close" %}</button>
                     </div>
                 </div>
 
@@ -334,8 +334,8 @@
                         {% include "public-draw-privacy.html" %}
                     </div>
                     <div class="modal-footer">
-                        <a class="btn btn-default btn-settings-back">Back</a>
-                        <a id="save" data-dismiss="modal" class="btn btn-primary">Save</a>
+                        <a class="btn btn-default btn-settings-back">{% trans "Back" %}</a>
+                        <a id="save" data-dismiss="modal" class="btn btn-primary">{% trans "Save" %}</a>
                     </div>
                 </div>
             </div>

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -320,7 +320,13 @@
                 <h4 class="modal-title">{% trans "Public draw settings" %}</h4>
             </div>
             <div class="modal-body">
-                <!-- To be filled -->
+                <ul class="list-group">
+                    <li class="list-group-item">Edit draw configuration</li>
+                    <li class="list-group-item">Invite people</li>
+                    <li class="list-group-item">Who can access your draw</li>
+                    <li class="list-group-item"><input type="checkbox"> Show the draw in "Recently created"</li>
+                    <li class="list-group-item"><input type="checkbox"> Enable chat</li>
+                </ul>
             </div>
             <div class="modal-footer">
                 <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -343,7 +343,7 @@
                     If you modify the draw's configuration the spectator will be notified about these changes. Are you sure you want to continue?
                 </div>
                 <div class="modal-footer">
-                    <a class="btn btn-default">Back</a>
+                    <a class="btn btn-default btn-settings-back">Back</a>
                     <a id="btn-edit-draw" class="btn btn-warning">Edit draw</a>
                 </div>
             </div>

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -96,7 +96,7 @@
                 <div class="col-xs-8 visible-xs"></div>
                 {% if is_public %}
                     {% if not public_draw_step %}
-                        <a id="settings-button" href="#" title="{%trans 'Public draw settings'%}" class="public-draw-settings col-xs-2 col-sm-2 col-sm-push-8 text-center ">
+                        <a id="settings-button" data-toggle="modal" href="#public-draw-settings" title="{%trans 'Public draw settings'%}" class="public-draw-settings col-xs-2 col-sm-2 col-sm-push-8 text-center ">
                             <span id="public-draw-options" class="fa fa-gear fa-2x"></span>
                         </a>
                     {% else %}
@@ -306,6 +306,21 @@
                         </div>
                     </div>
                 </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>
+                <button id="save" data-dismiss="modal" type="button" class="btn btn-primary">Save</button>
+            </div>
+        </div>
+
+        {# Hover panel to show the settings of the public draw (when it is published) #}
+        <div id="public-draw-settings" class="modal fade" tabindex="-1" style="display: none;" data-focus-on="input:first">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">{% trans "Public draw settings" %}</h4>
+            </div>
+            <div class="modal-body">
+                <!-- To be filled -->
             </div>
             <div class="modal-footer">
                 <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>

--- a/web/templates/public-draw-privacy.html
+++ b/web/templates/public-draw-privacy.html
@@ -1,0 +1,46 @@
+{% load i18n %}
+
+<div class="row">
+    <div class="col-md-12">
+        {% trans "Who do you want to access the draw?" %}
+        <div class="col-sm-8 col-sm-offset-2 text-center">
+            <div id="restriction-headings">
+                <div id="restriction-everyone" class="col-xs-3">{% trans "Everyone" %}</div>
+                <div id="restriction-password" class="col-xs-6">{% trans "With password or invitation" %}</div>
+                <div id="restriction-invited" class="col-xs-3">{% trans "Only with invitation" %}</div>
+            </div>
+            <div class="col-xs-8 col-sm-10 col-xs-offset-2 col-sm-offset-1 slide-bar-container">
+                <div data-selected="everyone" class="slide-bar ui-widget-content">
+                    <div class="slider-tick" style="left: 0%"></div>
+                    <div class="slider-tick" style="left: 50%"></div>
+                    <div class="slider-tick" style="left: 100%"></div>
+                    <div class="slide-selector" ></div>
+                </div>
+            </div>
+        </div>
+        <div id="restriction-extra" class="col-xs-12">
+            <div id="extra-everyone" class="col-xs-12">
+                {% trans "Everyone will be able to access the draw." %}
+                <div class="alert alert-info" role="alert">
+                    {% trans "Tip: Use this mode for informal and fast draws. Neither invitation nor password will be required!" %}
+                </div>
+            </div>
+            <div id="extra-password" class="col-xs-12">
+                {% trans "Only those who know the password will be able to access the draw." %}
+                <div class="col-xs-12 input-group">
+                    <span class="input-group-addon"><i class="fa fa-lock"></i></span>
+                    <input id="draw-password" type="password" class="form-control has-clear" name="password" placeholder="Password">
+                </div>
+                <div class="alert alert-info" role="alert">
+                    {% trans "Tip: You don't know exactly who is going to join the draw but still want some restriction? This is your draw!" %}
+                </div>
+            </div>
+            <div id="extra-invited" class="col-xs-12">
+                {% trans "You will be able to invite people by email when the draw is created." %}
+                <div class="alert alert-info" role="alert">
+                    {% trans "Tip: Use this mode for small/medium groups where you know well who do you want to join the draw." %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This PR has the implementation of the settings panel layout and adapts the existing JS to work with it.
Several functions are no implemented yet:
 - Edit draw: The fields need to be read-only by default
 - Invite people
 - Change the level of privacy (need some server-side changes)

Still, the layout it's kind of definitive and it will release load from next PR