### PR TITLE
Refactor index. Remove draw boxes' animation.

### DIFF
--- a/static/css/eas-home.css
+++ b/static/css/eas-home.css
@@ -46,6 +46,7 @@
     font-family: 'robotoregular', Helvetica, Arial, sans-serif;
     font-size: 18px;
     color: #6f6f6f;
+        flex: auto;
 }
 
 /* Added green color effect when draws are hovered */
@@ -76,66 +77,28 @@
 }
 
 .draw-box img {
-    height: auto;
-    width: 100%;
+    height: 34px;
+    width: auto;
 }
 
-.draw-box .draw-label {
-    flex: auto;
-}
-
-.draw-box .draw-img {
-    flex: 0 0 34px;
-    max-width: 34px;
-    height: auto;
+.fa-question{
+    padding-top: 0;
+    margin: -34px -10px 0 2px;
+    display: none !important;
+    visibility: hidden;
 }
 
 @media (min-width: 992px) {
-    .draw-box {
-        min-height: 36px;
-        padding-left: 15px;
-        padding-right: 15px;
-        margin-top: 5px;
-        background-color: #fff;
-        -moz-border-radius: 15px;
-        border-radius: 8px;
-        border: 1px #d6d6d6 solid;
-
-        display: -webkit-flex;
-        display: flex;
-        -webkit-flex-direction: row;
-        flex-direction: row;
-        -webkit-justify-content: flex-start;
-        justify-content: flex-start;
-        -webkit-align-items: flex-start;
-        align-items: flex-start;
-        max-height: 58px;
-
+    .draw-box img {
+        height: 56px;
+        width: auto;
     }
-
-    .draw-box-title {
-        font-family: 'robotoregular', Helvetica, Arial, sans-serif;
-        font-size: 18px;
-        color: #6f6f6f;
-        padding-top: 15px;
+    .draw-link:hover .fa-question{
+        padding-top: 0;
+        margin: -34px -10px 0 2px;
+        display: block !important;
+        visibility: visible;
     }
-
-    .no-padding {
-        padding-top: 0px;
-    }
-
-    .draw-box .draw-img {
-        flex: 0 0 56px;
-        max-width: 56px;
-        height: auto;
-    }
-
 }
 
-.draw-box-subtitle {
-    font-family: Helvetica, Arial, sans-serif;
-    font-style: italic;
-    font-size: 11px;
-    color: #bcbcbc;
-    display: none;
-}
+

--- a/web/templates/draw_box.html
+++ b/web/templates/draw_box.html
@@ -1,0 +1,18 @@
+{% load staticfiles %}
+{% load i18n %}
+
+{% comment %}
+    Parameters received:
+        - draw_type
+        - draw_icon
+        - title
+        - help
+{% endcomment %}
+
+<a class="draw-link" href="{% url 'draw' draw_type=draw_type publish=is_public %}">
+    <div class="draw-box">
+        <img src="{% static draw_icon %}"/>
+        <div class="draw-box-title text-center">{% trans title %}</div>
+        <span class="fa fa-question visible-lg" title="{% trans help %}"></span>
+    </div>
+</a>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -2,20 +2,6 @@
 {% load staticfiles %}
 {% load bootstrap %}
 {% load i18n %}
-{% block extra_jq_ready %}
-    $(function() {
-        $( ".draw-link" ).hover(
-            function() {
-                $(this).find(".draw-box-title" ).stop(true,true).addClass( "no-padding", 400 );
-              $(this).find(".draw-box-subtitle" ).stop(true,true).show( "clip", 400 );
-            },
-            function() {
-                $(this).find(".draw-box-title" ).stop(true,true).removeClass( "no-padding", 400 );
-              $(this).find(".draw-box-subtitle" ).stop(true,true).hide( "clip", 400 );
-            }
-        );
-    });
-{% endblock extra_jq_ready %}
 {% block content %}
 	<div class="row">
     <!-- Public Draw Info -->
@@ -27,72 +13,19 @@
 	        </div>
             <a href="{% url 'index' %}" class="cancel fa fa-times fa-2x"></a><br>
 	    </div>
-	{% endif %}
     <!-- End Public Draw Info -->
+	{% endif %}
 	</div>
     <div class="container-draws row">
         <div class="col-sm-6">
-            <a class="draw-link" href="{% url 'draw' draw_type='coin' publish=is_public %}">
-                <div class="draw-box">
-                    <div class="draw-img"><img src="{% static "img/coin.gif" %}"/></div>
-                    <div class="draw-label text-center">
-                        <div class="draw-box-title">{% trans "Flip a coin" %}</div>
-                        <div class="hidden-xs hidden-sm draw-box-subtitle">Afraid of taking the wrong decision? Don't hesitate and throw the coin!</div>
-                    </div>
-                </div>
-            </a>
-            <a class="draw-link" href="{% url 'draw' draw_type='card' publish=is_public %}">
-                <div class="draw-box">
-                    <div class="draw-img"><img src="{% static "img/cards.png" %}"/></div>
-                    <div class="draw-label text-center">
-                        <div class="draw-box-title">{% trans "Take a card" %}</div>
-                        <div class="hidden-xs hidden-sm draw-box-subtitle">Let's play some drinking games!</div>
-
-                    </div>
-                </div>
-            </a>
-            <a class="draw-link" href="{% url 'draw' draw_type='dice' publish=is_public %}">
-                <div class="draw-box">
-                    <div class="draw-img"><img src="{% static "img/dice.png" %}"/></div>
-                    <div class="draw-label text-center">
-                        <div class="draw-box-title">{% trans "Roll dice" %}</div>
-                        <div class="hidden-xs hidden-sm draw-box-subtitle">Didn't you have a dice? Just roll this one</div>
-
-                    </div>
-                </div>
-            </a>
+            {% include "draw_box.html" with draw_type="coin" draw_icon="img/coin.gif" title="Flip a coin" help="Afraid of taking the wrong decision? Don't hesitate and throw the coin!" %}
+            {% include "draw_box.html" with draw_type="card" draw_icon="img/cards.png" title="Take a card" help="Let's play some drinking games!" %}
+            {% include "draw_box.html" with draw_type="dice" draw_icon="img/dice.png" title="Roll a dice" help="Didn't you have a dice? Just roll this one" %}
         </div>
         <div class="col-sm-6">
-            <a class="draw-link" href="{% url 'draw' draw_type='number' publish=is_public %}">
-                <div class="draw-box">
-                    <div class="draw-img"><img src="{% static "img/random_number.png" %}"/></div>
-                    <div class="draw-label text-center">
-                        <div class="draw-box-title">{% trans "Random number" %}</div>
-                        <div class="hidden-xs hidden-sm draw-box-subtitle">Doing a raffle? Luck will decide who is the winner</div>
-
-                    </div>
-                </div>
-            </a>
-            <a class="draw-link" href="{% url 'draw' draw_type='item' publish=is_public %}">
-                <div class="draw-box">
-                    <div class="draw-img"><img src="{% static "img/random_item.png" %}"/></div>
-                    <div class="draw-label text-center">
-                        <div class="draw-box-title">{% trans "Pick random items from a list" %}</div>
-                        <div class="hidden-xs hidden-sm draw-box-subtitle">Doing a raffle? Luck will decide who is the winner</div>
-
-                    </div>
-                </div>
-            </a>
-            <a class="draw-link" href="{% url 'draw' draw_type='link_sets' publish=is_public %}">
-                <div class="draw-box">
-                    <div class="draw-img"><img src="{% static "img/item_association.png" %}"/></div>
-                    <div class="draw-label text-center">
-                        <div class="draw-box-title">{% trans "Associate items from two lists" %}</div>
-                        <div class="hidden-xs hidden-sm draw-box-subtitle">Cleaning the house? Allocate the tasks within your housemates</div>
-
-                    </div>
-                </div>
-            </a>
+            {% include "draw_box.html" with draw_type="number" draw_icon="img/random_number.png" title="Random number" help="Doing a raffle? Luck will decide who is the winner" %}
+            {% include "draw_box.html" with draw_type="item" draw_icon="img/random_item.png" title="Pick random items from a list" help="Doing a raffle? Luck will decide who is the winner" %}
+            {% include "draw_box.html" with draw_type="link_sets" draw_icon="img/item_association.png" title="Associate items from two lists" help="Cleaning the house? Allocate the tasks within your housemates" %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
The code for the draw boxes is refactored into a template.

The animation of the draw boxes to show the subtitle (or help) was not very good since it broke for long titles. It has been replace by a simpler tooltip. (so far with no theme, but it will be automatically included when the branch "create_public_draw" is merged)