### PR TITLE
Render share_type field automatically (by crispyforms)

### DIFF
--- a/server/forms/form_base.py
+++ b/server/forms/form_base.py
@@ -9,7 +9,7 @@ class FormBase(forms.Form):
     password = forms.CharField(required=False, widget=forms.HiddenInput())
     '''Password of the draw. If present, users can use it to access the draw'''
 
-    shared_type = forms.CharField(required=False)
+    shared_type = forms.CharField(required=False, widget=forms.HiddenInput())
     '''Type of shared type. None, Public, Invite. It needs to be rendered manually in the templates'''
 
     show_in_public_list = forms.BooleanField(required=False)

--- a/static/js/public_draw_manager.js
+++ b/static/js/public_draw_manager.js
@@ -32,10 +32,10 @@ PublicDraw.set_submition_type = function (current_step){
     });
 }
 
-// Thi function runs when the user make changes in the privacy of a public draw and click "Save" button
+// This function runs when the user make changes in the privacy of a public draw and click "Save" button
 // It store the corresponding values in the input field which will be POSTed
 PublicDraw.update_privacy_fields = function (){
-    var $shared_type_field = $('input#shared-type');
+    var $shared_type_field = $('input#id_shared_type');
     var mode = $('#privacy-selector').attr('data-selected');
     if (mode == "invited"){
         $('#id_password').val("");
@@ -64,7 +64,7 @@ PublicDraw.prepare_privacy_selection = function (){
 PublicDraw.settings = function () {
     // Update the slide selector to show the current level of privacy
     function initialize_slideselector () {
-        var current_privacy_level = $('input#shared-type').val();
+        var current_privacy_level = $('input#id_shared_type').val();
         var password = $('#id_password').val();
         var $privacySelector =  $('#privacy-selector');
         if (current_privacy_level == "Public")
@@ -195,7 +195,7 @@ PublicDraw.settings = function () {
         $('div#settings-privacy div.feedback').addClass('hide');
         PublicDraw.update_privacy_fields();
         var draw_id = $(this).attr("data-id");
-        var shared_type = $('input#shared-type').val();
+        var shared_type = $('input#id_shared_type').val();
         var password = $('input#id_password').val();
         $.get(PublicDraw.url_draw_privacy, {draw_id: draw_id, shared_type: shared_type, password: password}, function(data){
             /* The delay has the purpose to show "refresh" feedback when a to consecutive changes success */

--- a/web/templates/draws/draw_base.html
+++ b/web/templates/draws/draw_base.html
@@ -204,8 +204,6 @@
                 </div>
             </div>
 
-            {# shared-type: It's part of "FormBase". Can be "None", "Public" or "Invite" #}
-            <input id="shared-type" class="hidden" name="shared_type" value="{{ bom.shared_type }}"/>
             {# submit-type: Determine the type of submition, by default it's a toss (normal or public) #}
             <input class="hidden" name="submit-type" value="{% if is_public %}public_toss{% else %}toss{% endif %}"/>
             {# public-draw-step: Can be "Choose", "Confifure" or "Spread" #}

--- a/web/views.py
+++ b/web/views.py
@@ -464,8 +464,8 @@ def draw(request, draw_type=None,  draw_id=None, publish=None):
                 logger.info("Draw type mismatch, type: {0}".format(bom_draw.draw_type))
                 raise Http404
         else:
-            #Serve to create Draw
-            draw_form = globals()[form_name]()
+            # Even though it's a new form, some fields may have been preset before (i.e shared_type field)
+            draw_form = globals()[form_name](initial=bom_draw.__dict__)
 
     context['can_write'] = bom_draw.user_can_write(request.user)
     context['draw'] = draw_form


### PR DESCRIPTION
So far it was rendered manually in the template, but it wasn't necessary