### PR TITLE
Remove type_of_deck field 

### DIFF
--- a/server/forms/card_form.py
+++ b/server/forms/card_form.py
@@ -13,21 +13,21 @@ DECKS_CHOICES = (('french', _("French")),
 
 class CardDrawForm(FormBase):
     number_of_results = forms.IntegerField(label=_("Number of cards to draw"), required=True, initial=1, max_value=20)
-    type_of_deck = forms.ChoiceField(required=True, initial="french", choices=DECKS_CHOICES)
+    #type_of_deck = forms.ChoiceField(required=True, initial="french", choices=DECKS_CHOICES)
 
     def __init__(self, *args, **kwargs):
         super(CardDrawForm, self).__init__(*args, **kwargs)
 
         # Add "protected" class to the input that will be read-only when the draw is public
         self.fields['number_of_results'].widget.attrs.update({'class': 'protected'})
-        self.fields['type_of_deck'].widget.attrs.update({'class': 'protected'})
+        #self.fields['type_of_deck'].widget.attrs.update({'class': 'protected'})
 
         self.helper.label_class = 'col-xs-7 text-right'
         self.helper.field_class = 'col-xs-5'
         self.helper.layout = Layout(
             Row(
                 'number_of_results',
-                'type_of_deck',
+                #'type_of_deck',
             ),
         )
 

--- a/server/test/forms/card_form_test.py
+++ b/server/test/forms/card_form_test.py
@@ -5,19 +5,13 @@ from server.forms.card_form import CardDrawForm
 class CoinDrawFormTest(TestCase):
     def valid_ok_test(self):
         """CardDrawForm: Correct draw is valid"""
-        form_data = {'type_of_deck': 'french', 'number_of_results': 1}
+        form_data = {'number_of_results': 1}
         form = CardDrawForm(data=form_data)
         self.assertTrue(form.is_valid())
 
-    def invalid_type_of_deck_ko_test(self):
-        """CardDrawForm: Invalid type of deck is not valid"""
-        form_data = {'type_of_deck': 'this is not a deck', 'number_of_results': 1}
-        form = CardDrawForm(data=form_data)
-        self.assertFalse(form.is_valid())
-
     def too_many_results_ko_test(self):
         """CardDrawForm: Too many cards is not valid"""
-        form_data = {'type_of_deck': 'french', 'number_of_results': 45}
+        form_data = {'number_of_results': 45}
         form = CardDrawForm(data=form_data)
         self.assertFalse(form.is_valid())
 


### PR DESCRIPTION
Since we will likely add other decks, the code to handle several kind of decks remains in de bom, but the field has been commented in the form.