### PR TITLE
Allow users to update directly private draws

### DIFF
--- a/web/templates/draws/display_draw.html
+++ b/web/templates/draws/display_draw.html
@@ -153,10 +153,19 @@
             setTimeout(get_draw_details,2000);
         })();
 
-
+        PublicDraw.lock_fields();
+    {% else %}
+        $("#draw-form :input").change(function(changed_input) {
+            draw_updated_flag = true; //marks the draw as updated
+        });
     {% endif %}
-    PublicDraw.lock_fields();
+
+    var draw_updated_flag = false;
     $("#toss-button").click( function() {
+        if (draw_updated_flag) {
+            $("#edit-draw-save").click();
+            return;
+        }
         $.ajax({
             method : "GET",
             url   : "{% url 'ws_toss_draw' %}",

--- a/web/views.py
+++ b/web/views.py
@@ -254,6 +254,10 @@ def update_draw(request, draw_id):
             return render(request, "draws/display_draw.html", {"draw": draw_form, "bom": bom_draw})
         else:
             bom_draw.add_audit("DRAW_PARAMETERS")
+            #generate a result if a private draw
+            if not bom_draw.is_shared():
+                bom_draw.toss()
+
             mongodb.save_draw(bom_draw)
             logger.info("Updated draw: {0}".format(bom_draw))
             messages.error(request, _('Draw updated successfully'))


### PR DESCRIPTION
- when displaying draw, handling differently if the details where
  changed
- gnerate result when updating private draw