### PR TITLE
Fixup technica& layout issues

### DIFF
--- a/static/css/eas-base.css
+++ b/static/css/eas-base.css
@@ -252,6 +252,10 @@ h2,
     margin: 0 0 0;
 }
 
+.navbar-nav > .open > a {
+    background: rgba(194, 194, 194, 0.3) !important;
+}
+
 ul.nav.navbar-nav {
     margin-top: 0;
     margin-bottom: 0;

--- a/static/css/eas-draw-base.css
+++ b/static/css/eas-draw-base.css
@@ -128,6 +128,11 @@ a.fa:focus {
     margin-top: 20px;
 }
 
+#draw-form [type=submit]:disabled,
+#toss-button:disabled {
+    cursor: default
+}
+
 /***** INDIVIDUAL DRAWS *****/
 .checkbox {
     margin-top: 0;

--- a/static/css/eas-draw-base.css
+++ b/static/css/eas-draw-base.css
@@ -60,6 +60,10 @@ a.fa:focus {
     height: auto;
 }
 
+#edit-settings-button {
+    color: #4B7599;
+}
+
 @media (min-width: 992px) {
     .draw-heading .back-arrow img,
     .draw-heading .add-favourites img {

--- a/static/js/public_draw_displayer.js
+++ b/static/js/public_draw_displayer.js
@@ -62,7 +62,7 @@ PublicDraw.settings = function () {
     }
 
     // Open settings panel
-    $('#settings-button').click(function (){
+    $('#edit-settings-button').click(function (){
         init_settings_panel();
     });
 
@@ -94,7 +94,7 @@ PublicDraw.settings = function () {
         // Close settings panel
         $('#public-draw-settings').modal('hide');
         // Disable Settings button
-        $('settings-button').prop( "disabled", true );
+        $('#edit-settings-button').addClass( "hidden" );
         // Show the information div ("Separate items by commas...")
         $('#info-comma-separated').removeClass('hidden');
     });
@@ -104,9 +104,8 @@ PublicDraw.settings = function () {
     If the user cancel the draw edition, the page is reloaded.
     */
     $('a#edit-draw-cancel').click(function() {
-        // using replace instead on reload to avoid unintentional form submissions
-        var url = window.location.href;
-        window.location.replace(url);
+        // Don't use reload to avoid unintentional form submissions
+        window.location.href = String( window.location.href ).replace( "/#", "" );
     });
 
     /*

--- a/static/js/public_draw_displayer.js
+++ b/static/js/public_draw_displayer.js
@@ -169,6 +169,7 @@ PublicDraw.settings = function () {
 PublicDraw.lock_fields = function () {
     // Add read-only property to the inputs of the draw
     $('.protected').prop('readonly', true);
+    $('.protected').prop('title', PublicDraw.msg_tooltip_protected);
 
     // Add read-only property to inputs with tokenField
     $('.protected').tokenfield('readonly');

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -55,7 +55,9 @@
     <script>
         {% block extra_js %}{% endblock extra_js %}
         // Replaced default tooltip by the one from JQueryUI
-        $(document).tooltip();
+        $(document).tooltip({
+            track: true
+        });
 
         function place_lateral_columns(){
             var $site_frame = $('#site-frame');

--- a/web/templates/draws/display_draw.html
+++ b/web/templates/draws/display_draw.html
@@ -28,6 +28,11 @@
     {% endif %}
 {% endblock extra_js %}
 {% block extra_jq_ready %}
+    $(document).tooltip({
+        items: ".protected",
+        show: {delay: 500}
+    });
+
     // Hide/show the "allow repeat" checkbox based on the number of results
      var toggle_allow_repeat = function (){
         if ($('#id_number_of_results').val() > 1){
@@ -101,6 +106,7 @@
         PublicDraw.url_get_draw_details = "{% url 'ws_get_draw_details' %}";
         PublicDraw.url_update_draw = "{% url 'update_draw' draw_id=bom.pk %}";
         PublicDraw.url_update_settings = "{% url 'ws_update_share_settings' %}";
+        PublicDraw.msg_tooltip_protected = "{% trans "To edit the details go to Settings" %}";
         PublicDraw.setup();
 
         var share_url = document.domain + "{% url 'retrieve_draw' draw_id=bom.pk %}";
@@ -114,6 +120,8 @@
 
     var draw_updated_flag = false;
     $("#toss-button").click( function() {
+        $('#toss-button').prop('disabled',true);
+        $(this).text('{% trans "Loading..." %}');
         if (draw_updated_flag) {
             $("#draw-form").attr("action", "{% url 'update_draw' draw_id=bom.pk %}");
             $("#draw-form").submit();
@@ -174,11 +182,6 @@
         <!-- End Draw Heading -->
 
         <div class="col-sm-8 col-sm-offset-2">
-            {# pre-draw #}
-                {% if bom.draw_type == "LinksSetsDraw" %}
-                    <div class='alert alert-info' role='alert'>{%trans 'Separate items by commas. e.g: David S, Maria, Leo, ...'%}</div>
-                {% endif %}
-            {# end pre-draw #}
             <!-- Display Form -->
             {% crispy draw draw.helper %}
             <div class="col-xs-12 text-center">

--- a/web/templates/draws/display_draw.html
+++ b/web/templates/draws/display_draw.html
@@ -28,9 +28,9 @@
     {% endif %}
 {% endblock extra_js %}
 {% block extra_jq_ready %}
-    $(document).tooltip({
-        items: ".protected",
-        show: {delay: 500}
+    $(".protected").tooltip({
+        show: {delay: 500},
+        track: true,
     });
 
     // Hide/show the "allow repeat" checkbox based on the number of results
@@ -153,8 +153,9 @@
             <div class="col-xs-8 visible-xs"></div>
             {% if bom.is_shared %}
                 {% if not bom.owner or bom.owner == user.pk %}
-                    <a id="settings-button" data-toggle="modal" href="#public-draw-settings" title="{%trans 'Public draw settings'%}" class="public-draw-settings col-xs-2 col-sm-2 col-sm-push-8 text-center ">
+                    <a id="edit-settings-button" data-toggle="modal" href="#public-draw-settings" class="public-draw-settings col-xs-2 col-sm-2 col-sm-push-8 text-center ">
                         <span id="public-draw-options" class="fa fa-gear fa-2x"></span>
+                        <p>{% trans "Settings" %}</p>
                     </a>
                 {% else %}
                     <div class="hidden-xs col-xs-2 col-sm-2 col-sm-push-8"></div>

--- a/web/templates/draws/new_draw.html
+++ b/web/templates/draws/new_draw.html
@@ -55,7 +55,9 @@
 
     // Disable submit button after submitting
     $('form').submit(function() {
-        $(this).find("button[type='submit']").prop('disabled',true);
+        var $submit_btn = $(this).find("button[type='submit']");
+        $submit_btn.prop('disabled',true);
+        $submit_btn.text('{% trans "Loading..." %}');
         return true;
     });
 
@@ -116,7 +118,7 @@
                         </a>
                     </div>
                     <div id="recently-created" class="col-xs-12 form-group">
-                        <p data-toggle="tooltip" data-placement="top" title="{% trans "It will help your friends to find your draw faster" %}">
+                        <p title="{% trans "It will help your friends to find your draw faster" %}">
                             <input type="checkbox" name="show_in_public_list" checked>{% trans "Show the draw in the list 'Recently created'." %}
                         </p>
                     </div>

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -79,11 +79,6 @@
         }
     });
 
-    $(function() {
-        $(document).tooltip({
-            track: true
-        });
-    });
 {% endblock extra_jq_ready %}
 
 {% block content %}


### PR DESCRIPTION
Hide "settings" button while editing the draw
Fixup default tooltips in display_draw template
Force the tooltips to track the mouse
Add tooltip on protected inputs to indicate that the draw can be edited from the settings panel
Change text of submit buttons to "Loading..." when the form is being submitted
Show default cursor (instead of the prohibition one) when hovering disabled submition buttons