### PR TITLE
Fixup firefox bug 

### DIFF
--- a/web/templates/draws/display_draw.html
+++ b/web/templates/draws/display_draw.html
@@ -220,17 +220,17 @@
                 <!-- Button to toss -->
                 <div class="row btn-row">
                     {% if not bom.is_shared %}
-                        <button id="toss-button" type="button" class="btn btn-success">{% trans 'Toss' %}</button>
+                        <button id="toss-button" type="button" class="btn btn-success" autocomplete="off">{% trans 'Toss' %}</button>
                     {% else %}
                         {%if not bom.owner or bom.owner == user.pk %}
-                            <button id="toss-button" type="button" class="btn btn-success">{% trans 'Toss' %}</button>
-                            <button id="schedule-toss-button" type="button" class="btn" title="{% trans 'Schedule Toss' %}">
+                            <button id="toss-button" type="button" class="btn btn-success" autocomplete="off">{% trans 'Toss' %}</button>
+                            <button id="schedule-toss-button" type="button" class="btn" title="{% trans 'Schedule Toss' %}" autocomplete="off">
                                 <i class="fa fa-clock-o" ></i>
                             </button>
                             {# Buttons to save changes when editing an already published public draw #}
                             <div id="edit-draw-save-changes" class="hide">
                                 <a href="#" id="edit-draw-cancel" class="col-xs-6 btn btn-default">{% trans 'Cancel edition' %}</a>
-                                <button type="submit" id="edit-draw-save" class="col-xs-6 btn btn-primary">{% trans 'Save changes' %}</button>
+                                <button type="submit" id="edit-draw-save" class="col-xs-6 btn btn-primary" autocomplete="off">{% trans 'Save changes' %}</button>
                             </div>
                         {%else%}
                             <button id="toss-disabled-button" type="button" class="btn btn-success" disabled="disabled">{% trans 'Toss' %}</button>


### PR DESCRIPTION
It caused the browser to "remember" disabled buttons after refresh

http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing