### PR TITLE
Replace "Sign in" by "Log in"

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -739,7 +739,7 @@ msgstr ""
 "beneficios cuando crear tiradas publicas: "
 
 #: web/templates/index.html:39
-msgid "Only you can to toss"
+msgid "Only you can toss"
 msgstr "Solo tu puedes tirar"
 
 #: web/templates/index.html:40
@@ -754,19 +754,19 @@ msgstr "Solo tu puedes cambiar detalles de la tirada, invitar usuarios, etc..."
 msgid "It will be in your history for future access"
 msgstr "Permanecera en tu historial de tiradas para facilitar el acceso"
 
-#: web/templates/index.html:45
+#: web/templates/index.html:48
 msgid "Don't you have an account yet?"
 msgstr "¿Aún no tienes cuenta?"
 
-#: web/templates/index.html:46
-msgid "It takes only 30 seconds, and it's FREE!"
-msgstr "Solo tardarás 30 segundos, y es GRATIS!"
+#: web/templates/index.html:49
+msgid "It takes only 30 seconds, and <strong>it's totally FREE!</strong>"
+msgstr "Solo tardarás 30 segundos, y <strong>es totalmente GRATIS!</strong>"
 
-#: web/templates/index.html:51
+#: web/templates/index.html:55
 msgid "No thanks, I know what I'm doing"
 msgstr "No gracias, sé lo que hago"
 
-#: web/templates/index.html:64
+#: web/templates/index.html:67
 msgid "Let the luck decide!"
 msgstr "¡Deja que la suerte decida!"
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -270,11 +270,11 @@ msgstr ""
 msgid "PickForMe"
 msgstr "EchaloASuerte"
 
-#: web/templates/base.html:268 web/templates/base.html.py:361
-#: web/templates/base.html:384 web/templates/index.html:52
+#: web/templates/base.html:272 web/templates/base.html.py:365
+#: web/templates/base.html:388 web/templates/index.html:46
 #: web/templates/login.html:7 web/templates/login.html.py:34
-msgid "Sign in"
-msgstr "Registro"
+msgid "Log in"
+msgstr "Acceder"
 
 #: web/templates/base.html:278
 msgid "favourites"
@@ -314,8 +314,8 @@ msgid "Password"
 msgstr "Contraseña"
 
 #: web/templates/base.html:380
-msgid "Keep me signed in"
-msgstr "Recuérdame"
+msgid "Keep me logged in"
+msgstr "No cerrar sesión"
 
 #: web/templates/base.html:387 web/templates/login.html:36
 #: web/templates/profile.html:248
@@ -418,11 +418,11 @@ msgstr "Terminar"
 msgid "Type your message here..."
 msgstr "Escribe tu mensaje aquí..."
 
-#: web/templates/draws/display_draw.html:96
-msgid "Please, sign in to be able to use the chat"
+#: web/templates/draws/display_draw.html:97
+msgid "Please, log in to be able to use the chat"
 msgstr "Por favor, inicia sesión para usar el chat"
 
-#: web/templates/draws/display_draw.html:97
+#: web/templates/draws/display_draw.html:98
 msgid "Chat"
 msgstr "Chat"
 
@@ -730,9 +730,9 @@ msgstr "¿Toca limpiar la casa? Reparte las tareas con tus compañeros"
 msgid "May I say something?"
 msgstr "¿Puedo dar un consejo?"
 
-#: web/templates/index.html:37
+#: web/templates/index.html:38
 msgid ""
-"I've seen that you are not signed in.<br> Signing in has several benefits "
+"I've seen that you are not logged in.<br> Logging in has several benefits "
 "when creating a public draw:"
 msgstr ""
 "Parece que no estas registrado.<br> Los usuarios registrados tienen varios "

--- a/static/css/eas-base.css
+++ b/static/css/eas-base.css
@@ -789,3 +789,12 @@ a[disabled] {
     color: gray;
 }
 
+#create-account {
+    margin-top: 15px;
+}
+
+#create-account a {
+    font-weight: bold;
+}
+
+

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -269,7 +269,7 @@
                         {% else %}
                             <a id="login-dropdown-link" href="{% url 'login' %}">
                                 <span class="fa fa-user"></span>
-                                {% trans "Sign in" %}
+                                {% trans "Log in" %}
                             </a>
                         {% endif %}
                         <li class="nav-divider"></li>
@@ -362,7 +362,7 @@
                             <!-- End account dropdown panel -->
                         {% else %}
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                                <span class="fa fa-user" aria-hidden="true"></span> {% trans "Sign in" %}<b class="caret"></b>
+                                <span class="fa fa-user" aria-hidden="true"></span> {% trans "Log in" %}<b class="caret"></b>
                             </a>
                             <!-- Login panel -->
                             <ul class="dropdown-menu" style="padding: 15px;min-width: 250px;">
@@ -381,11 +381,11 @@
                                                 </div>
                                                 <div class="form-group checkbox">
                                                     <label>
-                                                        <input type="checkbox" class="checkboxinput checkbox" id="keep-logged" name="keep-logged"> {% trans "Keep me signed in" %}
+                                                        <input type="checkbox" class="checkboxinput checkbox" id="keep-logged" name="keep-logged"> {% trans "Keep me logged in" %}
                                                     </label>
                                                 </div>
                                                 <div class="form-group">
-                                                    <button id="login-button" type="submit" class="btn btn-success btn-block">{% trans "Sign in"%}
+                                                    <button id="login-button" type="submit" class="btn btn-success btn-block">{% trans "Log in"%}
                                                     </button>
                                                     <a class="forgot-password"
                                                        href="{% url 'forgot_password' %}">{% trans "Forgot your password?" %}</a>

--- a/web/templates/draws/display_draw.html
+++ b/web/templates/draws/display_draw.html
@@ -94,7 +94,7 @@
             "url_send_message": "{% url 'chat_add_message' %}",
             "draw_id": "{{ bom.pk }}",
             "msg_type_your_message": "{% trans 'Type your message here...' %}",
-            "msg_login_first": "{% trans 'Please, sign in to be able to use the chat'%}",
+            "msg_login_first": "{% trans 'Please, log in to be able to use the chat'%}",
             "msg_chat": "{% trans 'Chat' %}",
             "msg_send": "{% trans 'Send' %}"
         });

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -5,7 +5,7 @@
 
 {% block extra_jq_ready %}
     {% if not user.is_authenticated and is_public %}
-        $('#warning-sigin').modal('show');
+        $('#warning-login').modal('show');
     {% endif %}
 {% endblock extra_jq_ready %}
 
@@ -26,8 +26,8 @@
         </div>
     </div>
 
-    <!-- Warning "Sign in" modal -->
-    <div class="modal fade" id="warning-sigin" tabindex="-1" role="dialog" aria-labelledby="WarningSignin">
+    <!-- Warning "Log in" modal -->
+    <div class="modal fade" id="warning-login" tabindex="-1" role="dialog" aria-labelledby="WarningLogin">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
@@ -35,7 +35,7 @@
                     <h4 class="modal-title" id="myModalLabel">{% trans "May I say something?" %}</h4>
                 </div>
                 <div class="modal-body">
-                    {% trans "I've seen that you are not signed in.<br> Signing in has several benefits when creating a public draw:" %}
+                    {% trans "I've seen that you are not logged in.<br> Logging in has several benefits when creating a public draw:" %}
                     <ul>
                         <li>{% trans "Only you can toss" %}</li>
                         <li>{% trans "Only you can edit the details of the draw" %}</li>
@@ -43,7 +43,7 @@
                         <li>{% trans "The draw will be in your history for future access" %}</li>
                     </ul>
                     <div class="text-center" >
-                        <a href="{% url 'login' %}" type="button" class="btn btn-success">{% trans "Sign in" %}</a>
+                        <a href="{% url 'login' %}" type="button" class="btn btn-success">{% trans "Log in" %}</a>
                         <div id="create-account">
                             <p>{% trans "Don't you have an account yet?" %}<br/>
                             {% trans "It takes only 30 seconds, and <strong>it's totally FREE!</strong>" %}</p>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -37,20 +37,22 @@
                 <div class="modal-body">
                     {% trans "I've seen that you are not signed in.<br> Signing in has several benefits when creating a public draw:" %}
                     <ul>
-                        <li>{% trans "Only you can to toss" %}</li>
+                        <li>{% trans "Only you can toss" %}</li>
                         <li>{% trans "Only you can edit the details of the draw" %}</li>
                         <li>{% trans "Only you can change the level of privacy, invite or remove people" %}</li>
-                        <li>{% trans "It will be in your history for future access" %}</li>
+                        <li>{% trans "The draw will be in your history for future access" %}</li>
                     </ul>
                     <div class="text-center" >
-                        <p>{% trans "Don't you have an account yet?" %}</p>
-                        <p><strong>{% trans "It takes only 30 seconds, and it's FREE!" %}</strong></p>
-                        <a href="{% url 'register' %}" type="button" class="btn btn-success">{% trans "Sign up" %}</a>
+                        <a href="{% url 'login' %}" type="button" class="btn btn-success">{% trans "Sign in" %}</a>
+                        <div id="create-account">
+                            <p>{% trans "Don't you have an account yet?" %}<br/>
+                            {% trans "It takes only 30 seconds, and <strong>it's totally FREE!</strong>" %}</p>
+                            <a href="{% url 'register' %}" type="button" >{% trans "Create an account" %}</a>
+                        </div>
                     </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "No thanks, I know what I'm doing" %}</button>
-                    <a href="{% url 'login' %}" type="button" class="btn btn-primary">{% trans "Sign in" %}</a>
                 </div>
             </div>
         </div>

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -4,7 +4,7 @@
 {% block content %}
     <div id="login" class="row">
         <div class="col-sm-6 col-sm-offset-3 text-center">
-            <h1>{% trans "Sign in" %}</h1>
+            <h1>{% trans "Log in" %}</h1>
             <form class="form-horizontal" name="LoginForm" action="{% url 'login' %}" method="post">
             {% csrf_token %}
             {% if next %}
@@ -31,7 +31,7 @@
             {% endif %}
             <div class="row control-group">
                 <div class="controls text-center">
-                    <button id="login-button" type="submit" class="btn btn-success">{% trans "Sign in" %}</button>
+                    <button id="login-button" type="submit" class="btn btn-success">{% trans "Log in" %}</button>
                 </div>
                 <a href="{% url 'forgot_password' %}">{% trans "Forgot your password?" %}</a>
             </div>


### PR DESCRIPTION
"Sign in" and "Sign up" are visually too close so slower to scan

The warning panel to suggest the user to log in has been also modified to be clearer