### PR TITLE
Fixup images chrome

### DIFF
--- a/static/css/eas-base.css
+++ b/static/css/eas-base.css
@@ -120,7 +120,7 @@ h2,
 
 .draw-box img {
     height: 34px;
-    width: auto;
+    width: 34px;
 }
 
 .fa-question{


### PR DESCRIPTION
Give a fix size to draw images

There is a bug with the flex containers that affect to chrome and was causing the images to lose the ratio in XS sizes