### PR TITLE
Fixed up typo in url to login

### DIFF
--- a/echaloasuerte/settings/common.py
+++ b/echaloasuerte/settings/common.py
@@ -219,7 +219,7 @@ ALLOWED_HOSTS = [
     '92.222.28.167',
 ]
 
-LOGIN_URL = "/accounts/sigin/"
+LOGIN_URL = "/accounts/login/"
 
 #EMAIL settings
 DEFAULT_FROM_EMAIL = "echaloasuerte@gmail.com"

--- a/web/urls.py
+++ b/web/urls.py
@@ -21,7 +21,7 @@ urlpatterns += patterns(
     url(r'^draw/try/(?P<draw_type>[^/]+)/$', views.try_draw, name="try_draw"),
     url(r'^accounts/signup/$', views.register, name='register'),
     url(r'^accounts/forgot_password/$', views.under_construction, name='forgot_password'),
-    url(r'^accounts/sigin/$', views.login_user, name='login'),
+    url(r'^accounts/login/$', views.login_user, name='login'),
     url(r'^accounts/profile/$', views.profile, name='profile'),
 
     # web services


### PR DESCRIPTION
Actually, the url has been renamed from signin to login for consistancy