### PR TITLE
Fixup bug when initializing forms

### DIFF
--- a/server/draw_factory.py
+++ b/server/draw_factory.py
@@ -75,7 +75,7 @@ def create_form(draw_type, draw_data=None, initial=None):
 
     form_class = REGISTRY[draw_type]["form"]
     if draw_data:
-        form = form_class(draw_data)
+        form = form_class(initial=draw_data)
     else:
         if initial:
             form = form_class(initial=initial)

--- a/web/views.py
+++ b/web/views.py
@@ -175,7 +175,8 @@ def create_draw(request, draw_type, is_public):
                       {"draw": draw_form, "is_public": is_public, "draw_type": draw_type, "default_title": draw_form.DEFAULT_TITLE})
     else:
         LOG.debug("Received post data: {0}".format(request.POST))
-        draw_form = draw_factory.create_form(draw_type, request.POST)
+        draw_data = request.POST.copy()
+        draw_form = draw_factory.create_form(draw_type, draw_data)
         try:
             bom_draw = draw_form.build_draw()
         except DrawFormError:


### PR DESCRIPTION
When the forms are initialized with data from the server, it should be done through initial.

Currently was causing problems Random Items and Link Sets.

The problem was only in develop, luckily
http://dev.pickforme.net/draw/new/item/