### PR TITLE
Fixup some layout problems

### DIFF
--- a/static/css/eas-draw-base.css
+++ b/static/css/eas-draw-base.css
@@ -126,8 +126,10 @@ a.fa:focus {
     margin-top: 20px;
 }
 
-#draw-form [type=submit]:disabled,
-#toss-button:disabled {
+#create-and-toss:disabled,
+#try:disabled,
+#publish:disabled,
+#shared-draw-toss:disabled{
     cursor: default
 }
 

--- a/static/js/public_draw_manager.js
+++ b/static/js/public_draw_manager.js
@@ -52,7 +52,7 @@ PublicDraw.setup_settings_panel = function () {
     $('a#edit-draw-confirmation').click(function() {
         PublicDraw.lock_fields(false);
         // Hide the toss button
-        $('#toss-button, #schedule-toss-button').addClass('hide');
+        $('#shared-draw-toss, #schedule-toss-button').addClass('hide');
         // Show the "Save changes" and "Cancel edition" buttons
         $('div#edit-draw-save-changes').removeClass('hide');
         // Close settings panel

--- a/web/templates/draws/display_draw.html
+++ b/web/templates/draws/display_draw.html
@@ -175,12 +175,12 @@
                                 <i class="fa fa-clock-o" ></i>
                             </button>
                             {# Buttons to save changes when editing an already published public draw #}
-                            <div id="edit-draw-save-changes" class="hide">
+                            <div id="edit-draw-save-changes" class="btn-row hide">
                                 <a href="#" id="edit-draw-cancel" class="col-xs-6 btn btn-default">{% trans 'Cancel edition' %}</a>
                                 <button type="button" id="edit-draw-save" class="col-xs-6 btn btn-primary submit-lockable" autocomplete="off">{% trans 'Save changes' %}</button>
                             </div>
                         {%else%}
-                            <a id="toss-disabled-button" class="btn btn-success" disabled="disabled">{% trans 'Toss' %}</a>
+                            <button id="toss-disabled-button" class="btn btn-success" disabled="disabled">{% trans 'Toss' %}</button>
                             <div class="alert alert-warning alert-dismissible" role="alert">
                                 <a class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></a>
                                 {%trans 'Only the owner of the draw can toss. '%}[{{bom.owner}}]


### PR DESCRIPTION
- The toss button was not hidden when edited shared draws
- Add padding to the ```Edit draw``` and ```Cancel``` buttons
- Replace ```<a>``` with ```<button>``` tag (since anchors can not be disabled by default)