### PR TITLE
Register draw creations in Google Analytics from the clients

### DIFF
--- a/static/js/draw_manager.js
+++ b/static/js/draw_manager.js
@@ -224,6 +224,9 @@
 
             this.create_draw(
                 callback_done = function( data, textStatus, xhr ){
+                    // Register the event in Google Analytics
+                    ga('send', 'event', 'create_draw', that.options.draw_type, 'shared');
+
                     // Get the url to the draw
                     var url_draw_api = xhr.getResponseHeader('Location');
                     var url_draw_web = url_draw_api.replace(/api\/v[\d\.]+\//g,'');
@@ -261,6 +264,9 @@
 
             this.create_draw(
                 callback_done = function( data, textStatus, xhr ){
+                    // Register the event in Google Analytics
+                    ga('send', 'event', 'create_draw', that.options.draw_type, 'private');
+
                     // Get the url to the draw
                     var url_draw_api = xhr.getResponseHeader('Location');
                     var url_draw_web = url_draw_api.replace(/api\/v[\d\.]+\//g,'');

--- a/web/common.py
+++ b/web/common.py
@@ -9,7 +9,6 @@ from django.core.mail import send_mail
 
 import logging
 import time
-from web.google_analytics import ga_track_event
 
 
 LOG = logging.getLogger("echaloasuerte")
@@ -142,17 +141,6 @@ def time_it(func):
             return func(*args, **kwargs)
 
     return _
-
-
-def ga_track_draw(bom_draw, action):
-    """Sends a notification of action to google analytics
-
-    :bom_draw: draw to send information about
-    :action: action to send
-    """
-    shared_type = 'public' if bom_draw.is_shared else 'private'
-    ga_track_event(category=action, action=bom_draw.draw_type, label=shared_type)
-
 
 def set_owner(draw, request):
     """Best effort to set the owner given a request"""


### PR DESCRIPTION
We were missing metadata when registering events from the server