### PR TITLE
Fixup draw type values (i.e. "number" instead of "RandomNumberDraw")

### DIFF
--- a/server/bom/draw_base.py
+++ b/server/bom/draw_base.py
@@ -78,7 +78,8 @@ class BaseDraw(object):
         self.owner = owner
         """ID of the owner of the draw"""
 
-        self.draw_type = type(self).__name__
+        from server import draw_factory
+        self.draw_type = draw_factory.get_draw_name(type(self).__name__)
         """Type of the draw"""
 
         self.creation_time = creation_time if creation_time is not None else datetime.datetime.utcnow().replace(

--- a/server/mongodb/driver.py
+++ b/server/mongodb/driver.py
@@ -7,6 +7,8 @@ import logging
 import datetime
 import pytz
 
+from server import draw_factory
+
 logger = logging.getLogger("echaloasuerte")
 
 
@@ -26,7 +28,7 @@ def safe_connection(func):
 def build_draw(doc):
     """Given a python dict that represnets a draw, builds it"""
     try:
-        return eval(doc["draw_type"])(**doc)
+        return draw_factory.create_draw(doc["draw_type"], doc)
     except Exception as e:
         logger.error("Error when decoding a draw. Exception: {1}. Draw: {0} ".format(doc, e))
         raise

--- a/web/rest_api/draw.py
+++ b/web/rest_api/draw.py
@@ -232,7 +232,6 @@ class DrawResource(resources.Resource):
                 bundle.data[att] = getattr(bundle.obj, att)
         for att in self.HIDDEN_ATTRIBUTES:
             bundle.data.pop(att)
-        bundle.data["type"] = draw_factory.get_draw_name(bundle.data["type"])
         return bundle
 
     def detail_uri_kwargs(self, bundle_or_obj):

--- a/web/templates/draws/display_draw.html
+++ b/web/templates/draws/display_draw.html
@@ -29,9 +29,9 @@
 {% endblock extra_head %}
 {% block extra_js %}
     //Precaching the images
-    {% if bom.draw_type == "CoinDraw" %}
+    {% if bom.draw_type == "coin" %}
         coin.setup('{{ STATIC_URL }}' + "img/img_coin/");
-    {% elif bom.draw_type == "DiceDraw"  %}
+    {% elif bom.draw_type == "dice"  %}
         D6.baseUrl = '{{ STATIC_URL }}' + "img/img_dice/"
         D6Animator.getImageBank("", D6.baseUrl);
     {% endif %}

--- a/web/views.py
+++ b/web/views.py
@@ -159,10 +159,9 @@ def display_draw(request, draw_id):
     Given a draw id, retrieves it and returns the data required to display it
     """
     bom_draw = MONGO.retrieve_draw(draw_id)
-    draw_type = draw_factory.get_draw_name(bom_draw.draw_type)
     if bom_draw.check_read_access(request.user):
         draw_data = bom_draw.__dict__.copy()
-        draw_form = draw_factory.create_form(draw_type, initial=draw_data)
+        draw_form = draw_factory.create_form(bom_draw.draw_type, initial=draw_data)
         return render(request, "draws/display_draw.html",
                       {"draw": draw_form, "bom": bom_draw})
     else:


### PR DESCRIPTION
The attribute ```draw_type``` was storing the template name (i.e. "DiceDraw" or "RandomNumberDraw"). Now it's storing the identifier used in other cases for each draw type for consistency (i.e. "dice" or "number")