### PR TITLE
Give better names to Tournament and Random Groups

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -54,17 +54,17 @@ window.cookieconsent_options = {"message":"{% trans 'This website uses cookies t
     </div>
     <div class="container-draws row">
         <div class="col-sm-6">
-            {% include "snippets/snippet_draw_box.html" with draw_type="coin" draw_icon="img/draw_icons/coin.png" title=_("Flip a coin") help=_("Afraid of taking the wrong decision? Don't hesitate and throw the coin!") %}
-            {% include "snippets/snippet_draw_box.html" with draw_type="card" draw_icon="img/draw_icons/cards.png" title=_("Take a card") help=_("Let's play some drinking games!") %}
-            {% include "snippets/snippet_draw_box.html" with draw_type="dice" draw_icon="img/draw_icons/dice.png" title=_("Roll a dice") help=_("Don't you have a die? Just roll this one") %}
-            {% include "snippets/snippet_draw_box.html" with draw_type="tournament" draw_icon="img/draw_icons/tournament.png" title=_("Tournament") help=_("Organising a competition? This is your draw!") %}
-            {% include "snippets/snippet_draw_box.html" with draw_type="groups" draw_icon="img/draw_icons/groups.png" title=_("Random Groups") help=_("Needs to group a bunch of people or items? Click here!") %}
+            {% include "snippets/snippet_draw_box.html" with draw_type="coin" draw_icon="img/draw_icons/coin.png" title="Flip a coin" help="Afraid of taking the wrong decision? Don't hesitate and throw the coin!" %}
+            {% include "snippets/snippet_draw_box.html" with draw_type="card" draw_icon="img/draw_icons/cards.png" title="Take a card" help="Let's play some drinking games!" %}
+            {% include "snippets/snippet_draw_box.html" with draw_type="dice" draw_icon="img/draw_icons/dice.png" title="Roll a dice" help="Don't you have a die? Just roll this one" %}
+            {% include "snippets/snippet_draw_box.html" with draw_type="tournament" draw_icon="img/draw_icons/tournament.png" title="Tournament" help="Organising a competition? This is your draw!" %}
+            {% include "snippets/snippet_draw_box.html" with draw_type="groups" draw_icon="img/draw_icons/groups.png" title="Random Groups" help="Needs to group a bunch of people or items? Click here!" %}
         </div>
         <div class="col-sm-6">
-            {% include "snippets/snippet_draw_box.html" with draw_type="number" draw_icon="img/draw_icons/random_number.png" title=_("Random number") help=_("Doing a raffle? Luck will decide who is the winner") %}
-            {% include "snippets/snippet_draw_box.html" with draw_type="letter" draw_icon="img/draw_icons/random_letter.png" title=_("Random letter") help=_("Not sure what letter to start the lis with? Just click here :)") %}
-            {% include "snippets/snippet_draw_box.html" with draw_type="item" draw_icon="img/draw_icons/random_item.png" title=_("Pick random items from a list") help=_("Doing a raffle? Luck will decide who is the winner") %}
-            {% include "snippets/snippet_draw_box.html" with draw_type="link_sets" draw_icon="img/draw_icons/item_association.png" title=_("Associate items from two lists") help=_("Cleaning the house? Allocate the tasks within your housemates") %}
+            {% include "snippets/snippet_draw_box.html" with draw_type="number" draw_icon="img/draw_icons/random_number.png" title="Random number" help="Doing a raffle? Luck will decide who is the winner" %}
+            {% include "snippets/snippet_draw_box.html" with draw_type="letter" draw_icon="img/draw_icons/random_letter.png" title="Random letter" help="Not sure what letter to start the lis with? Just click here :)" %}
+            {% include "snippets/snippet_draw_box.html" with draw_type="item" draw_icon="img/draw_icons/random_item.png" title="Pick random items from a list" help="Doing a raffle? Luck will decide who is the winner" %}
+            {% include "snippets/snippet_draw_box.html" with draw_type="link_sets" draw_icon="img/draw_icons/item_association.png" title="Associate items from two lists" help="Cleaning the house? Allocate the tasks within your housemates" %}
         </div>
     </div>
 


### PR DESCRIPTION
The idea is to give a name the describes better what the draw does (i.e. *Tournaments* sounds like you are going to play something)

So the proposals are:
* Tournament --> Organise tournament
* Random groups  --> Build groups / Generate groups?

Additionally, this PR removes a translation since titles and help seemed to be translated twice

**Note: Translation for Random Groups is missing.** Someone with linux, run gettext :P