### PR TITLE
Prefix web urls with language

### DIFF
--- a/echaloasuerte/urls.py
+++ b/echaloasuerte/urls.py
@@ -1,15 +1,49 @@
 from django.conf.urls import patterns, include, url
 from django.conf.urls.i18n import i18n_patterns
+from django.views.generic import TemplateView, RedirectView
 
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
-                       url(r'^i18n/', include('django.conf.urls.i18n')),
-                       url(r'^admin/', include(admin.site.urls)),
-                       )
+urlpatterns = patterns(
+    '',
+    url(r'^i18n/', include('django.conf.urls.i18n')),
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^robots\.txt$', TemplateView.as_view(template_name='robots.txt')),
+)
 
-urlpatterns += patterns('',
-                        url(r'^', include('web.urls')),
-                        )
+urlpatterns += i18n_patterns(
+    '',
+    url(r'^', include('web.urls')),
+)
+
+urlpatterns += patterns(
+    '',
+    url(r'^api/', include('web.rest_api.urls'))
+)
+
+# deprecated urls
+urlpatterns += patterns(
+    '',
+    url(r'index.php', RedirectView.as_view(url="/", permanent=True)),
+    url(r'elegirSalas.php', RedirectView.as_view(url="/", permanent=True)),
+    url(r'contacto.php', RedirectView.as_view(url="/", permanent=True)),
+    url(r'acerca.php', RedirectView.as_view(url="about.html", permanent=True)),
+    url(r'^ws/draw_add_users/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/draw_remove_users/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/chat/details/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/chat/add/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/draw/share_settings/update/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/draw/schedule-toss/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/draw/try/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/draw/validate/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/draw/toss/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/draw/create/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^draw/(?P<draw_id>[0-9a-g]+)/update/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^draw/try/(?P<draw_type>[^/]+)/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/update_profile/$',  RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/favourites/remove/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/favourites/add/$', RedirectView.as_view(url="/", permanent=True)),
+    url(r'^ws/check_access_to_draw/$', RedirectView.as_view(url="/", permanent=True)),
+)

--- a/func_test/shared_draw_test.py
+++ b/func_test/shared_draw_test.py
@@ -158,7 +158,8 @@ class SharedDrawTest(BrowserStackTest):
         )
         driver.find_element_by_id('invite').click()
         url_invite = driver.find_element_by_css_selector('#settings-invite .url-share').get_attribute('value')
-        self.assertEqual(url_draw, url_invite)
+        self.assertEqual(url_draw.split('draw')[-1],
+                         url_invite.split('draw')[-1])
         driver.find_element_by_id('invite-emails-tokenfield').send_keys('iker_jimenez@test.com')
         driver.find_element_by_id('send-emails').click()
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -12,11 +12,11 @@
     {% if "echaloasuerte" in request.get_host %}
         <meta name="keywords" content="echaloasuerte, suerte, dados, cara, cruz, aleatorio, distribuido, a distancia, azar, echalo, pick, ban, cara o cruz, loteria, random, draw" />
         <meta name="description" content="Deja que el azar tome una decision por ti. Olvidate de los papelitos, numeros, listas, rifas, etc... Esta es tu pagina, y cada uno desde su ordenador!" />
-        <link rel="alternate" hreflang="en" href="//chooserandom.com/" />
+        <link rel="alternate" hreflang="en" href="//chooserandom.com/en/" />
     {% else %}
         <meta name="keywords" content="chooserandom, pickforme, luck, dice, tails, head, random, distributed, multiple user, chance, pick, ban, heads or tails, lottery, random, draw" />
         <meta name="description" content="Not sure about a choice? Choose random! Heads or tails, lottery, etc..." />
-        <link rel="alternate" hreflang="es" href="//echaloasuerte.com/" />
+        <link rel="alternate" hreflang="es" href="//echaloasuerte.com/es/" />
     {% endif %}
     <title>{% block title %}{% endblock title %}{% trans 'Choose Random' %}</title>
 

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,6 +1,5 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
-from django.views.generic.base import RedirectView
 from web import views
 from web import web_services as ws
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
@@ -10,9 +9,6 @@ urlpatterns = patterns(None)
 urlpatterns += patterns(
     '',
     url(r'^$', views.index, name='index'),
-
-    url(r'^join_draw.html$', views.join_draw, name="join_public_draw"),
-
     url(r'^about.html$', TemplateView.as_view(template_name='about.html'), name="about"),
     url(r'^draw/(?P<draw_id>[0-9a-g]+)/$', views.display_draw, name="retrieve_draw"),
     url(r'^draw/new/(?P<draw_type>[^/]+)/public/$', views.create_draw, {'is_public': True}, name="create_public_draw"),
@@ -21,35 +17,13 @@ urlpatterns += patterns(
     url(r'^accounts/forgot_password/$', views.under_construction, name='forgot_password'),
     url(r'^accounts/login/$', views.login_user, name='login'),
     url(r'^accounts/profile/$', views.profile, name='profile'),
+    url(r'^join_draw.html$', views.join_draw, name="join_public_draw"),
+)
 
-    # web services
+# web services
+urlpatterns += patterns(
+    '',
     url(r'^ws/feedback/$', ws.feedback, name="ws_feedback"),
-
-    # redirect
-    url(r'index.php', RedirectView.as_view(url="/", permanent=True)),
-    url(r'elegirSalas.php', RedirectView.as_view(url="/", permanent=True)),
-    url(r'contacto.php', RedirectView.as_view(url="/", permanent=True)),
-    url(r'acerca.php', RedirectView.as_view(url="about.html", permanent=True)),
-    url(r'^ws/draw_add_users/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/draw_remove_users/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/chat/details/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/chat/add/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/draw/share_settings/update/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/draw/schedule-toss/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/draw/try/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/draw/validate/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/draw/toss/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/draw/create/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^draw/(?P<draw_id>[0-9a-g]+)/update/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^draw/try/(?P<draw_type>[^/]+)/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/update_profile/$',  RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/favourites/remove/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/favourites/add/$', RedirectView.as_view(url="/", permanent=True)),
-    url(r'^ws/check_access_to_draw/$', RedirectView.as_view(url="/", permanent=True)),
-
-    url(r'^robots\.txt$', TemplateView.as_view(template_name='robots.txt')),
-
-    url(r'^api/', include('web.rest_api.urls'))
 )
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Prefix all urls with the two leters that identify the language. This is
important to ease google indexing of the site.

All urls without language will redirect to the language prefixed site
using users browser language