### PR TITLE
Fixup draw title input size

### DIFF
--- a/static/js/autoGrowArea.js
+++ b/static/js/autoGrowArea.js
@@ -70,7 +70,9 @@
                 }
                 var max_width = $("#draw-title-container").width();
                 $(this).width(max_width);
+                check()
             });
+            $(this).blur();
 
         });
 


### PR DESCRIPTION
Now it has by default its expected width (It was not fully initialized).
The title input has a maximum 3 rows