### PR TITLE
Initialize the breadcrumb only in shared draws

### DIFF
--- a/static/js/shared_draw_creator.js
+++ b/static/js/shared_draw_creator.js
@@ -67,7 +67,7 @@ SharedDrawCreator.update_breadcrumb = function (target_step){
 };
 
 // Initialize the links in the breadcrumb
-SharedDrawCreator.setup = function(){
+SharedDrawCreator.setup_breadcrumb = function(){
     var $breadcrumb = $('.breadcrumb-shared-draw');
     $breadcrumb.find('#general').click(SharedDrawCreator.show_general_step);
     $breadcrumb.find('#configure').click(SharedDrawCreator.show_configure_step);

--- a/web/templates/draws/new_draw.html
+++ b/web/templates/draws/new_draw.html
@@ -47,7 +47,6 @@
         $(this).select();
     });
 
-    SharedDrawCreator.setup();
 
     var $draw_maneger = $('#draw-form').drawManager({
         draw_type: "{{ draw_type }}",
@@ -64,6 +63,7 @@
     });
 
     {% if is_public %}
+        SharedDrawCreator.setup_breadcrumb();
         $("#try").click( function() {
             $draw_maneger.drawManager('try_draw');
         });


### PR DESCRIPTION
It it's breaking the JS in the normal draws