### PR TITLE
Wrap meta description within a template block

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -9,14 +9,15 @@
     <meta charset="utf-8">
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no">
-    <meta name="description" content="
+    <meta name="description" content="{% spaceless %}
         {% block description %}
             {% if "echaloasuerte" in request.get_host %}
                 Deja que el azar tome una decision por ti. Olvídate de los papelitos, números, listas, rifas, etc... Esta es tu página, y cada uno desde su ordenador!
             {% else %}
                 Not sure about a choice? Choose random! Heads or tails, lottery, etc...
             {% endif %}
-        {% endblock description %}" />
+        {% endblock description %}
+    {% endspaceless %}" />
     {% if "echaloasuerte" in request.get_host %}
         <meta name="keywords" content="echaloasuerte, suerte, dados, cara, cruz, aleatorio, distribuido, a distancia, azar, echalo, pick, ban, cara o cruz, loteria, random, draw" />
         <link rel="alternate" hreflang="en" href="//chooserandom.com/" />

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -9,13 +9,19 @@
     <meta charset="utf-8">
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no">
+    <meta name="description" content="
+        {% block description %}
+            {% if "echaloasuerte" in request.get_host %}
+                Deja que el azar tome una decision por ti. Olvídate de los papelitos, números, listas, rifas, etc... Esta es tu página, y cada uno desde su ordenador!
+            {% else %}
+                Not sure about a choice? Choose random! Heads or tails, lottery, etc...
+            {% endif %}
+        {% endblock description %}" />
     {% if "echaloasuerte" in request.get_host %}
         <meta name="keywords" content="echaloasuerte, suerte, dados, cara, cruz, aleatorio, distribuido, a distancia, azar, echalo, pick, ban, cara o cruz, loteria, random, draw" />
-        <meta name="description" content="Deja que el azar tome una decision por ti. Olvidate de los papelitos, numeros, listas, rifas, etc... Esta es tu pagina, y cada uno desde su ordenador!" />
         <link rel="alternate" hreflang="en" href="//chooserandom.com/" />
     {% else %}
         <meta name="keywords" content="chooserandom, pickforme, luck, dice, tails, head, random, distributed, multiple user, chance, pick, ban, heads or tails, lottery, random, draw" />
-        <meta name="description" content="Not sure about a choice? Choose random! Heads or tails, lottery, etc..." />
         <link rel="alternate" hreflang="es" href="//echaloasuerte.com/" />
     {% endif %}
     <title>{% block title %}{% endblock title %}{% trans 'Choose Random' %}</title>


### PR DESCRIPTION
Then we can use the draw's description as the page meta description (shown when a draw is shared on social media, for instance).

I also think that have only one description for all the pages is horrible for SEO