### PR TITLE
Don't allow participants modifications when updating a Raffle

### DIFF
--- a/web/rest_api/draw.py
+++ b/web/rest_api/draw.py
@@ -47,7 +47,7 @@ class DrawResource(resources.Resource):
     HIDDEN_ATTRIBUTES = ['draw_type', '_id']
     FORBIDDEN_ATTRIBUTES = ['results', 'owner', '_id', 'pk', 'creation_time',
                             'last_updated_time', 'audit']
-    FROZEN_ATTRIBUTES = ['type']
+    FROZEN_ATTRIBUTES = ['type', 'participants']
 
     class Meta:
         resource_name = 'draw'


### PR DESCRIPTION
With this PR is not possible to edit the participants when updating a draw. Which somehow seems logic.

Anyway, if later we want to allow the owner to remove participants we can make an AJAX call when he is edditing the draw and clicking on the tokenfield's _x_

Closes #646