### PR TITLE
Fixup protected fields

### DIFF
--- a/static/js/shared_draw_manager.js
+++ b/static/js/shared_draw_manager.js
@@ -125,7 +125,7 @@ SharedDraw.setup_settings_panel = function () {
 SharedDraw.lock_fields = function(locked){
     var $protected_fields = $('.protected');
     var $protected_hidden_fields = $('.protected-hidden');
-    var $protected_inputs = $('input.protected');
+    var $protected_inputs = $('input.protected, textarea.protected');
     var $protected_buttons = $('button.protected');
     var $protected_tokenfields = $('input.protected.eas-tokenfield');
     if (locked){
@@ -152,7 +152,7 @@ SharedDraw.lock_fields = function(locked){
         $protected_hidden_fields.toggleClass('hidden', false);
 
         // Remove read-only property to the inputs of the draw
-        $protected_fields.removeProp('readonly');
+        $protected_inputs.removeProp('readonly');
 
         // Remove disabled class from buttons
         $protected_buttons.toggleClass('disabled', false);

--- a/static/js/shared_draw_manager.js
+++ b/static/js/shared_draw_manager.js
@@ -13,6 +13,7 @@ SharedDraw.defaults = {
     msg_login_to_subscribe: "Please, log in to be able to subscribe to a draw",
     msg_error_subscribe: "There was an issue when subscribing to the draw :(",
     msg_error_unsubscribe: "There was an issue when unsubscribing to the draw :(",
+    msg_tooltip_protected: "To edit the details go to Settings"
 };
 
 SharedDraw.setup_settings_panel = function () {


### PR DESCRIPTION
It was possible to edit the draw title and description (well, any textarea) in shared draws. Changes were of course not saved but they shouldn't be editable anyway...