### PR TITLE
Fix service-worker.js url

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -281,7 +281,7 @@
 
         /* Register service workers */
         if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register("service-worker.js").then(function(registration) {
+            navigator.serviceWorker.register("/service-worker.js").then(function(registration) {
                 // Registration was successful
                 console.log('ServiceWorker registration successful with scope: ',    registration.scope);
             }).catch(function(err) {


### PR DESCRIPTION
It's failing to load currently, and is filling the error logs with:

    ...
    Not Found: /draw/new/letter/service-worker.js
    Not Found: /draw/new/number/service-worker.js
    Not Found: /draw/5754a7ce741c12aad6b0e7/service-worker.js
    Not Found: /draw/5754a7dd741f12a9a0fee1/service-worker.js
    Not Found: /draw/new/number/service-worker.js
    Not Found: /draw/5754a7ff1c1f12aad6b0e8/service-worker.js
    Not Found: /draw/new/coin/service-worker.js
    Not Found: /draw/new/card/service-worker.js
    Not Found: /draw/5754a8741c1f12a9a0fee2/service-worker.js
    ...

This commit fixes the error.