### PR TITLE
manage.py: Stop using removed config file

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "echaloasuerte.settings.develop")
-
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
This is causing problems when executing 'manage.py' script. The
issue was introduced in f6a1b0.