### PR TITLE
Fix ga event for private tosses

### DIFF
--- a/static/js/draw_manager.js
+++ b/static/js/draw_manager.js
@@ -180,17 +180,6 @@
                 heightStyle: "content"
             });
 
-
-            if (this.options.is_shared){
-                // Initialize input to submit emails as a tokenFields
-                $('input#invite-emails').tokenfield({
-                    createTokensOnBlur:true,
-                    delimiter: [',',' '],
-                    inputType: 'email',
-                    minWidth: 150
-                });
-            }
-
             /**
             * Store callback functions to render results dynamically
             * render: Specify how to render the result
@@ -574,8 +563,7 @@
             if (Object.keys(this.edited_fields).length > 0) {
                 this.update(
                     callback_done = function (){
-                        var is_shared = that.options.is_shared ? 'shared' : 'private';
-                        ga('send', 'event', 'update', that.options.draw_type, is_shared);
+                        ga('send', 'event', 'update', that.options.draw_type, 'private');
                         var $result_headers = $('.ui-accordion-header');
                         $result_headers.each(function(){
                             var $this = $(this);

--- a/web/templates/draws/display_draw.html
+++ b/web/templates/draws/display_draw.html
@@ -120,6 +120,7 @@
     {% endif %}
 
     var $draw_maneger = $('#draw-form').drawManager({
+        is_shared: "{{ bom.is_shared }}",
         url_toss: "{% url 'api_draw_toss' api_name="v1" pk=bom.pk %}",
         draw_type: "{{ bom.draw_type }}",
         url_update: "{% url 'api_dispatch_detail' api_name="v1" resource_name="draw" pk=bom.pk %}",


### PR DESCRIPTION
The parameter is_shared wasn't passed down to the draw_manager. The only consequence was that the ga events for tossing were always private.

The removed code was never run but it duplicated in shared_draw_manager.